### PR TITLE
fix: security hardening, ownership checks, N+1 queries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
-/pusk
-/pusk-linux
-data/
-*.db
-.env
 .git
+tests
+data
+pusk-bin
+pusk.bak
+pusk-old*
+demo-bots
+*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           go-version: '1.25.x'
       - run: go build -o pusk ./cmd/pusk/
       - run: go vet ./...
+      - run: go test -race ./...
       - name: gofmt
         run: test -z "$(gofmt -l .)"
       - name: JS function integrity

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,7 @@ RUN mkdir -p data
 EXPOSE 8443
 VOLUME /app/data
 ENV PUSK_ADDR=:8443
+RUN addgroup -S pusk && adduser -S pusk -G pusk && chown -R pusk:pusk /app
+USER pusk
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://localhost:8443/api/health || exit 1
 CMD ["./pusk"]

--- a/cmd/pusk/demo.go
+++ b/cmd/pusk/demo.go
@@ -42,6 +42,7 @@ func initDemo(db *store.Store) {
 			return
 		}
 		slog.Info("demo user created", "user", "guest")
+		db.SetUserRole(guest.ID, "member")
 	}
 
 	// Test users (admin uses ADMIN_TOKEN, these are regular users for demo)

--- a/internal/api/client_auth.go
+++ b/internal/api/client_auth.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"sync"
 	"time"
 )
@@ -122,6 +123,10 @@ func (a *ClientAPI) register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !regexp.MustCompile(`^[a-zA-Z0-9_-]{2,32}$`).MatchString(req.Username) {
+		jsonErr(w, "username must be 2-32 alphanumeric characters", 400)
+		return
+	}
 	if len(req.Pin) < 6 {
 		jsonErr(w, "password must be at least 6 characters", 400)
 		return
@@ -183,6 +188,10 @@ func (a *ClientAPI) acceptInvite(w http.ResponseWriter, r *http.Request) {
 
 	if req.Code == "" || req.Username == "" || req.Pin == "" {
 		jsonErr(w, "code, username and pin required", 400)
+		return
+	}
+	if !regexp.MustCompile(`^[a-zA-Z0-9_-]{2,32}$`).MatchString(req.Username) {
+		jsonErr(w, "username must be 2-32 alphanumeric characters", 400)
 		return
 	}
 	if len(req.Pin) < 6 {

--- a/internal/api/client_channels.go
+++ b/internal/api/client_channels.go
@@ -35,19 +35,13 @@ func (a *ClientAPI) broadcastChannel(s *store.Store, channelID int64, orgID, evT
 func (a *ClientAPI) channelReaders(w http.ResponseWriter, r *http.Request) {
 	channelID, _ := strconv.ParseInt(r.PathValue("channelID"), 10, 64)
 	s := a.db(r)
-
-	users, _ := s.ListUsers()
-	type reader struct {
-		UserID   int64  `json:"user_id"`
-		Username string `json:"username"`
-		LastRead int64  `json:"last_read_id"`
+	readers, err := s.ChannelReadersJoin(channelID)
+	if err != nil {
+		jsonErr(w, "internal error", 500)
+		return
 	}
-	var readers []reader
-	for _, u := range users {
-		lastRead := s.GetLastRead(channelID, u.ID)
-		if lastRead > 0 {
-			readers = append(readers, reader{UserID: u.ID, Username: u.Username, LastRead: lastRead})
-		}
+	if readers == nil {
+		readers = []store.ChannelReader{}
 	}
 	json.NewEncoder(w).Encode(readers)
 }
@@ -97,27 +91,14 @@ func (a *ClientAPI) ackChannelMessage(w http.ResponseWriter, r *http.Request) {
 
 func (a *ClientAPI) listChannels(w http.ResponseWriter, r *http.Request) {
 	userID := UserIDFromCtx(r.Context())
-	channels, err := a.db(r).ListChannels()
+	s := a.db(r)
+	result, err := s.ListChannelsForUser(userID)
 	if err != nil {
 		jsonErr(w, "internal error", 500)
 		return
 	}
-	type channelInfo struct {
-		ID              int64  `json:"id"`
-		Name            string `json:"name"`
-		Description     string `json:"description,omitempty"`
-		Subscribed      bool   `json:"subscribed"`
-		Unread          int    `json:"unread"`
-		PinnedMessageID int64  `json:"pinned_message_id"`
-	}
-	s := a.db(r)
-	result := make([]channelInfo, 0, len(channels))
-	for _, ch := range channels {
-		result = append(result, channelInfo{
-			ID: ch.ID, Name: ch.Name, Description: ch.Description, PinnedMessageID: s.GetPinnedMessage(ch.ID),
-			Subscribed: s.IsSubscribed(ch.ID, userID),
-			Unread:     s.UnreadCount(ch.ID, userID),
-		})
+	if result == nil {
+		result = []store.ChannelInfo{}
 	}
 	json.NewEncoder(w).Encode(result)
 }
@@ -462,8 +443,8 @@ func createAlertmanagerSilence(amURL, username, alertText string) {
 
 	now := time.Now()
 	silence := map[string]interface{}{
-		"matchers": []map[string]string{
-			{"name": "alertname", "value": alertname, "isRegex": "false"},
+		"matchers": []map[string]interface{}{
+			{"name": "alertname", "value": alertname, "isRegex": false},
 		},
 		"startsAt":  now.Format(time.RFC3339),
 		"endsAt":    now.Add(1 * time.Hour).Format(time.RFC3339),

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -302,6 +302,13 @@ func (h *Handler) editMessageText(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Ownership check: verify bot owns this chat
+	chatBotID, _ := h.db(r).ChatBotID(req.ChatID)
+	if chatBotID != bot.ID {
+		jsonResp(w, 403, APIResponse{OK: false, Error: "forbidden"})
+		return
+	}
+
 	markup := ""
 	if req.ReplyMarkup != nil {
 		raw := string(req.ReplyMarkup)
@@ -326,7 +333,7 @@ func (h *Handler) editMessageText(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) deleteMessage(w http.ResponseWriter, r *http.Request) {
-	_, err := h.authBot(r)
+	bot, err := h.authBot(r)
 	if err != nil {
 		jsonResp(w, 401, APIResponse{OK: false, Error: "Unauthorized"})
 		return
@@ -335,6 +342,13 @@ func (h *Handler) deleteMessage(w http.ResponseWriter, r *http.Request) {
 	var req DeleteMessageRequest
 	if err := decodeBody(r, &req); err != nil {
 		jsonResp(w, 400, APIResponse{OK: false, Error: err.Error()})
+		return
+	}
+
+	// Ownership check: verify bot owns this chat
+	chatBotID, _ := h.db(r).ChatBotID(req.ChatID)
+	if chatBotID != bot.ID {
+		jsonResp(w, 403, APIResponse{OK: false, Error: "forbidden"})
 		return
 	}
 

--- a/internal/bot/relay.go
+++ b/internal/bot/relay.go
@@ -16,7 +16,22 @@ import (
 )
 
 var relayUpgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+		u, err := url.Parse(origin)
+		if err != nil {
+			return false
+		}
+		host := u.Hostname()
+		reqHost := r.Host
+		if h, _, err := net.SplitHostPort(reqHost); err == nil {
+			reqHost = h
+		}
+		return host == reqHost || host == "localhost" || host == "127.0.0.1"
+	},
 }
 
 // RelayHub manages WebSocket connections from bots for webhook relay.

--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -3,7 +3,9 @@
 package org
 
 import (
+	crand "crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -184,7 +186,9 @@ func (m *Manager) Register(slug, name, adminUser, adminPin string) error {
 	s.SetUserRole(admin.ID, "admin")
 
 	// Create default system bot (needed for channels)
-	botToken := slug + "-system-" + fmt.Sprintf("%d", len(m.orgs))
+	tokenBytes := make([]byte, 16)
+	crand.Read(tokenBytes)
+	botToken := hex.EncodeToString(tokenBytes)
 	sysBot, _ := s.CreateBot(botToken, name+" Bot")
 	if sysBot != nil {
 		m.registerTokenLocked(botToken, slug)

--- a/internal/store/files.go
+++ b/internal/store/files.go
@@ -48,6 +48,8 @@ func (s *Store) ValidateFileToken(token string) (int64, error) {
 		s.db.Exec("DELETE FROM file_tokens WHERE token=?", token)
 		return 0, fmt.Errorf("file token expired")
 	}
+	// Consume token (single-use)
+	s.db.Exec("DELETE FROM file_tokens WHERE token=?", token)
 	return userID, nil
 }
 

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -69,7 +69,7 @@ func (s *Store) SetUserRole(userID int64, role string) error {
 func (s *Store) IsAdmin(userID int64) bool {
 	var role string
 	s.db.QueryRow("SELECT COALESCE(role,'member') FROM users WHERE id=?", userID).Scan(&role)
-	return role == "admin" || userID == 1
+	return role == "admin"
 }
 
 func (s *Store) DeleteUser(userID int64) error {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -24,7 +24,7 @@
 <div id="landing">
   <div class="land-left">
     <h1 class="land-logo">Pusk</h1>
-    <div class="land-tag">Алерты и координация для ops-команд</div>
+    <div class="land-tag">Self-hosted замена Telegram для алертов и координации</div>
     <p class="land-desc">Self-hosted Telegram Bot API. Мониторинг, алерты, командный чат без внешних зависимостей. Работает, когда всё остальное заблокировано.</p>
     <div class="land-stats">
       <div class="land-stat"><b>23 MB</b><span>Docker</span></div>
@@ -62,7 +62,7 @@ bot = Bot(token="my-token",
   </div>
   <div class="land-right">
     <div class="land-chat-hdr"><span class="land-chat-dot"></span> DemoBot — публичная демо-среда</div>
-    <div class="land-chat-body" id="land-msgs"></div>
+    <div class="land-chat-body" id="land-msgs"><div class="m-empty" id="land-fallback">Загрузка демо...</div></div>
     <div class="land-chat-input">
       <input id="land-input" placeholder="Напишите боту..." aria-label="Message to demo bot">
       <button id="land-send" aria-label="Send">&#8594;</button>

--- a/web/static/js/landing.js
+++ b/web/static/js/landing.js
@@ -46,6 +46,7 @@ export async function initLandingChat(){
   const chat=await landApi('POST','/api/bots/1/start');
   if(!chat.id)return;S.landChat=chat.id;
   const msgs=await landApi('GET',`/api/chats/${chat.id}/messages`);
+  const fb=document.getElementById("land-fallback");if(fb)fb.remove();
   if(msgs&&msgs.length)msgs.reverse().forEach(m=>{
     const who=m.sender==='bot'?'DemoBot':'Guest';
     landAddMsg(who,m.text,fmtTime(m.date),m.reply_markup);

--- a/web/static/js/views.js
+++ b/web/static/js/views.js
@@ -107,7 +107,7 @@ export function setMsgHandlers(handlers){
 // ── Auth ──
 export function auth(r){S.token=r.token;set('token',S.token);set('uid',r.user_id);set('uname',r.username||'');if(r.role)set('role',r.role);if(r.org){set('org',r.org);const orgs=getJSON('orgs')||{};orgs[r.org]={token:r.token,user:r.username,name:r.org,role:r.role||'member'};setJSON('orgs',orgs)}showApp()}
 
-export function logout(){S.token=null;S.curChat=null;S.curChan=null;remove('token');remove('uid');remove('uname');remove('view');disconnectWS();$('landing').style.display='flex';$('auth').style.display='none';$('app').style.display='none';$('fab').style.display='none';$('settings').style.display='none';$('settings-bg').style.display='none';window.initLandingChat()}
+export function logout(){S.token=null;S.curChat=null;S.curChan=null;remove('token');remove('uid');remove('uname');remove('view');remove('role');remove('org');disconnectWS();$('landing').style.display='flex';$('auth').style.display='none';$('app').style.display='none';$('fab').style.display='none';$('settings').style.display='none';$('settings-bg').style.display='none';window.initLandingChat()}
 
 // ── App views ──
 export async function showApp(){$('auth').style.display='none';$('app').style.display='flex';const u=get('uname')||'?';$('hdr-ava').textContent=u[0].toUpperCase();$('hdr-ava').style.background=nameColor(u);$('hdr-name').textContent=u;connectWS();registerPush();await showList();const v=get('view');if(v){try{const o=JSON.parse(v);if(o.t==='chat')openChat(o.id,o.n);else if(o.t==='ch')openChan(o.id,o.n)}catch{}}}
@@ -138,7 +138,7 @@ export async function showList(){S.curChat=null;S.curChan=null;S.replyToId=0;$('
       el.appendChild(row);
     }
   }
-  const isAdmin=get("role")==="admin"||get("uid")==="1";
+  const isAdmin=get("role")==="admin";
   if(bots&&bots.length){
     const secTitle=document.createElement('div');secTitle.className='sec-title';secTitle.textContent=t('bots');el.appendChild(secTitle);
     for(const b of bots){

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -4,6 +4,7 @@ const SHELL = [
   '/',
   '/css/pusk.css',
   '/js/state.js',
+  '/js/storage.js',
   '/js/util.js',
   '/js/views.js',
   '/js/ws.js',


### PR DESCRIPTION
## Summary
- Guest demo user set to member role (was admin via user_id=1 fallback)
- Bot API delete/edit verify chat ownership before acting
- System bot tokens use crypto/rand instead of predictable slug-system-N
- Relay WebSocket uses proper origin check (was allow-all)
- File tokens consumed on use (single-use, prevent replay)
- Username validated: alphanumeric 2-32 chars on register and invite
- isRegex boolean (not string) in Alertmanager silence payload
- N+1 queries replaced with JOIN-based ListChannelsForUser/ChannelReadersJoin
- Dockerfile: non-root user + HEALTHCHECK + updated .dockerignore
- go test -race added to CI pipeline
- SW precache includes storage.js
- Logout clears role/org from localStorage
- Landing tagline updated, demo chat fallback text added

## Test plan
- [ ] Build passes: `go build -o pusk-bin ./cmd/pusk/`
- [ ] Tests pass: `go test -race ./...`
- [ ] Guest login gets member role, not admin
- [ ] Bot API editMessage/deleteMessage returns 403 for wrong bot
- [ ] File token works once, second use fails
- [ ] Registration rejects usernames with special chars
- [ ] Docker build succeeds with non-root user