### PR TITLE
ci: fix CodeQL go-version 1.25→1.26

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
CodeQL Autobuild failed because go-version was 1.25.x but go.mod requires 1.26. This caused PR #14 (Dependabot) to show 62% compatibility.