### PR TITLE
chore: bump SW v77, add mark-read to OpenAPI spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1498,6 +1498,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/OkResponse'
 
+
+  /api/channels/{channelID}/mark-read:
+    post:
+      tags: [Client Channels]
+      operationId: clientChannelMarkRead
+      summary: Mark channel as read
+      description: |
+        Marks the channel as read up to the given message ID.
+        If last_read_id is omitted, marks up to the latest message.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: channelID
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                last_read_id:
+                  type: integer
+                  format: int64
+                  description: Message ID to mark as read up to. Defaults to latest message.
+      responses:
+        '200':
+          description: Marked as read.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OkResponse'
   /api/channels/{channelID}/messages:
     get:
       tags: [Client Channels]

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -1,5 +1,5 @@
 // Pusk Service Worker — App Shell cache + Push notifications
-const CACHE = 'pusk-v76';
+const CACHE = 'pusk-v77';
 const SHELL = [
   '/',
   '/css/pusk.css',


### PR DESCRIPTION
SW cache bump v76→v77 forces clients to reload JS after PR #42 (mark-read fix). Adds POST /api/channels/{channelID}/mark-read to OpenAPI spec.