### PR TITLE
test: unit tests for auth, ws hub, org manager (+37)

### DIFF
--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestNewJWTService_PanicsOnEmptySecret(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on empty secret")
+		}
+	}()
+	NewJWTService("", 168)
+}
+
+func TestGenerateAndValidate(t *testing.T) {
+	j := NewJWTService("test-secret-key", 168)
+	tok, err := j.Generate(42, "myorg", "admin")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	claims, err := j.Validate(tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if claims.UserID != 42 {
+		t.Errorf("UserID = %d, want 42", claims.UserID)
+	}
+	if claims.OrgID != "myorg" {
+		t.Errorf("OrgID = %q, want myorg", claims.OrgID)
+	}
+	if claims.Username != "admin" {
+		t.Errorf("Username = %q, want admin", claims.Username)
+	}
+}
+
+func TestValidate_InvalidToken(t *testing.T) {
+	j := NewJWTService("secret", 168)
+	_, err := j.Validate("not-a-jwt")
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+	if err != ErrInvalidToken {
+		t.Errorf("err = %v, want ErrInvalidToken", err)
+	}
+}
+
+func TestValidate_WrongSecret(t *testing.T) {
+	j1 := NewJWTService("secret1", 168)
+	j2 := NewJWTService("secret2", 168)
+	tok, _ := j1.Generate(1, "org", "user")
+	_, err := j2.Validate(tok)
+	if err == nil {
+		t.Fatal("expected error for wrong secret")
+	}
+}
+
+func TestValidate_ExpiredToken(t *testing.T) {
+	j := NewJWTService("secret", 1)
+	claims := Claims{
+		UserID:   1,
+		OrgID:    "org",
+		Username: "user",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+			Subject:   "user",
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStr, _ := token.SignedString([]byte("secret"))
+	_, err := j.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestValidate_NoneSigningMethod(t *testing.T) {
+	claims := Claims{
+		UserID:   1,
+		OrgID:    "org",
+		Username: "user",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: "user",
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tokenStr, _ := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	j := NewJWTService("secret", 168)
+	_, err := j.Validate(tokenStr)
+	if err == nil {
+		t.Fatal("expected error for none signing method")
+	}
+}
+
+func TestGenerate_SetsTTL(t *testing.T) {
+	j := NewJWTService("secret", 24) // 24 hours
+	tok, _ := j.Generate(1, "org", "user")
+	claims, err := j.Validate(tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := claims.ExpiresAt.Time
+	// Should expire roughly 24h from now (within 1 minute tolerance)
+	diff := time.Until(exp)
+	if diff < 23*time.Hour || diff > 25*time.Hour {
+		t.Errorf("expiry diff = %v, want ~24h", diff)
+	}
+}
+
+func TestValidate_EmptyString(t *testing.T) {
+	j := NewJWTService("secret", 168)
+	_, err := j.Validate("")
+	if err == nil {
+		t.Fatal("expected error for empty token string")
+	}
+}

--- a/internal/org/manager_test.go
+++ b/internal/org/manager_test.go
@@ -13,7 +13,7 @@ func tempManager(t *testing.T) *Manager {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	m, err := NewManager(dir)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/org/manager_test.go
+++ b/internal/org/manager_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package org
+
+import (
+	"os"
+	"testing"
+)
+
+func tempManager(t *testing.T) *Manager {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "pusk-org-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	m, err := NewManager(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { m.Close() })
+	return m
+}
+
+func TestNewManager_CreatesDefault(t *testing.T) {
+	m := tempManager(t)
+	orgs := m.List()
+	if len(orgs) != 1 {
+		t.Fatalf("orgs = %d, want 1", len(orgs))
+	}
+	if orgs[0].Slug != "default" {
+		t.Fatalf("slug = %q, want default", orgs[0].Slug)
+	}
+}
+
+func TestGet_Default(t *testing.T) {
+	m := tempManager(t)
+	s, err := m.Get("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil store")
+	}
+	if s.OrgID != "default" {
+		t.Fatalf("OrgID = %q, want default", s.OrgID)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	m := tempManager(t)
+	_, err := m.Get("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent org")
+	}
+}
+
+func TestGet_LazyInit(t *testing.T) {
+	m := tempManager(t)
+	// First call creates the store
+	s1, err := m.Get("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Second call returns cached store
+	s2, err := m.Get("default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s1 != s2 {
+		t.Fatal("expected same store instance on second call")
+	}
+}
+
+func TestRegister_Success(t *testing.T) {
+	m := tempManager(t)
+	err := m.Register("myteam", "My Team", "admin", "pass1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	orgs := m.List()
+	if len(orgs) != 2 {
+		t.Fatalf("orgs = %d, want 2", len(orgs))
+	}
+	s, err := m.Get("myteam")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.OrgID != "myteam" {
+		t.Fatalf("OrgID = %q", s.OrgID)
+	}
+}
+
+func TestRegister_CreatesAdminAndBot(t *testing.T) {
+	m := tempManager(t)
+	err := m.Register("neworg", "New Org", "admin", "pass1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := m.Get("neworg")
+	// Admin should be able to auth
+	user, err := s.AuthUser("admin", "pass1234")
+	if err != nil {
+		t.Fatalf("admin auth failed: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected non-nil user")
+	}
+}
+
+func TestRegister_Duplicate(t *testing.T) {
+	m := tempManager(t)
+	_ = m.Register("dup", "Dup", "admin", "pass1234")
+	err := m.Register("dup", "Dup2", "admin2", "pass5678")
+	if err == nil {
+		t.Fatal("expected error for duplicate slug")
+	}
+}
+
+func TestRegister_InvalidSlugs(t *testing.T) {
+	m := tempManager(t)
+	invalids := []string{
+		"a",       // too short
+		"",        // empty
+		"A-Upper", // uppercase
+		"my org",  // space
+		"---",     // no alphanumeric
+		"../evil", // path traversal
+	}
+	for _, slug := range invalids {
+		err := m.Register(slug, "Test", "admin", "pass")
+		if err == nil {
+			t.Errorf("expected error for slug %q", slug)
+		}
+	}
+}
+
+func TestRegister_ValidSlugs(t *testing.T) {
+	m := tempManager(t)
+	valids := []string{"ab", "my-team", "team-42", "a1"}
+	for _, slug := range valids {
+		err := m.Register(slug, "Test "+slug, "admin", "pass1234")
+		if err != nil {
+			t.Errorf("unexpected error for slug %q: %v", slug, err)
+		}
+	}
+}
+
+func TestTokenRegistry(t *testing.T) {
+	m := tempManager(t)
+	_ = m.Register("org1", "Org 1", "admin", "pass1234")
+	m.RegisterToken("tok123", "org1")
+	slug, err := m.OrgByToken("tok123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slug != "org1" {
+		t.Fatalf("slug = %q, want org1", slug)
+	}
+}
+
+func TestOrgByToken_UnknownFallsToDefault(t *testing.T) {
+	m := tempManager(t)
+	slug, err := m.OrgByToken("unknown-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slug != "default" {
+		t.Fatalf("slug = %q, want default (fallback)", slug)
+	}
+}
+
+func TestGetByToken(t *testing.T) {
+	m := tempManager(t)
+	_ = m.Register("org2", "Org 2", "admin", "pass1234")
+	m.RegisterToken("tok456", "org2")
+	s, slug, err := m.GetByToken("tok456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slug != "org2" {
+		t.Fatalf("slug = %q", slug)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil store")
+	}
+}
+
+func TestGetByToken_Unknown(t *testing.T) {
+	m := tempManager(t)
+	// Unknown token should fallback to default org
+	s, slug, err := m.GetByToken("nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slug != "default" {
+		t.Fatalf("slug = %q, want default", slug)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil store for default")
+	}
+}
+
+func TestManagerClose(t *testing.T) {
+	m := tempManager(t)
+	_ = m.Register("close-test", "Close", "admin", "pass1234")
+	_, _ = m.Get("close-test")
+	m.Close() // should not panic
+}
+
+func TestRegisterToken_Overwrite(t *testing.T) {
+	m := tempManager(t)
+	_ = m.Register("org-a", "A", "admin", "pass1234")
+	_ = m.Register("org-b", "B", "admin", "pass1234")
+	m.RegisterToken("shared-tok", "org-a")
+	m.RegisterToken("shared-tok", "org-b") // overwrite
+	slug, _ := m.OrgByToken("shared-tok")
+	if slug != "org-b" {
+		t.Fatalf("slug = %q, want org-b after overwrite", slug)
+	}
+}

--- a/internal/ws/hub_test.go
+++ b/internal/ws/hub_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package ws
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// mockConn creates a Conn without a real websocket
+func mockConn(userID int64, key string) *Conn {
+	return &Conn{
+		send:   make(chan []byte, 64),
+		UserID: userID,
+		Key:    key,
+	}
+}
+
+func TestHubRegisterUnregister(t *testing.T) {
+	h := NewHub()
+	c := mockConn(1, "org:1")
+	h.Register("org:1", c)
+	if h.Online() != 1 {
+		t.Fatalf("Online = %d, want 1", h.Online())
+	}
+	if !h.IsConnected("org:1") {
+		t.Fatal("expected connected")
+	}
+	h.Unregister("org:1", c)
+	if h.Online() != 0 {
+		t.Fatalf("Online = %d, want 0", h.Online())
+	}
+	if h.IsConnected("org:1") {
+		t.Fatal("expected disconnected")
+	}
+}
+
+func TestHubMultiDevice(t *testing.T) {
+	h := NewHub()
+	c1 := mockConn(1, "org:1")
+	c2 := mockConn(1, "org:1")
+	h.Register("org:1", c1)
+	h.Register("org:1", c2)
+	if h.Online() != 1 {
+		t.Fatalf("Online = %d, want 1 (same key)", h.Online())
+	}
+	h.Unregister("org:1", c1)
+	if !h.IsConnected("org:1") {
+		t.Fatal("expected still connected with second conn")
+	}
+	h.Unregister("org:1", c2)
+	if h.IsConnected("org:1") {
+		t.Fatal("expected disconnected after both removed")
+	}
+}
+
+func TestHubStatus(t *testing.T) {
+	h := NewHub()
+	if h.GetStatus("org:1") != "offline" {
+		t.Fatal("expected offline for unregistered key")
+	}
+	c := mockConn(1, "org:1")
+	h.Register("org:1", c)
+	if h.GetStatus("org:1") != "online" {
+		t.Fatal("expected online after register")
+	}
+	h.SetStatus("org:1", "away")
+	if h.GetStatus("org:1") != "away" {
+		t.Fatal("expected away")
+	}
+	h.Unregister("org:1", c)
+	if h.GetStatus("org:1") != "offline" {
+		t.Fatal("expected offline after unregister")
+	}
+}
+
+func TestHubStatusMultiDevice_AwayIgnored(t *testing.T) {
+	h := NewHub()
+	c1 := mockConn(1, "org:1")
+	c2 := mockConn(1, "org:1")
+	h.Register("org:1", c1)
+	h.Register("org:1", c2)
+	// With 2 connections, "away" should be ignored (online wins)
+	h.SetStatus("org:1", "away")
+	if h.GetStatus("org:1") != "online" {
+		t.Fatal("expected online with multiple connections")
+	}
+}
+
+func TestHubStatusSingleDevice_AwayWorks(t *testing.T) {
+	h := NewHub()
+	c := mockConn(1, "org:1")
+	h.Register("org:1", c)
+	h.SetStatus("org:1", "away")
+	if h.GetStatus("org:1") != "away" {
+		t.Fatal("expected away with single connection")
+	}
+}
+
+func TestHubActiveChannel(t *testing.T) {
+	h := NewHub()
+	c := mockConn(1, "org:1")
+	h.Register("org:1", c)
+	h.SetActiveChannel("org:1", 5)
+	if h.GetActiveChannel("org:1") != 5 {
+		t.Fatalf("active channel = %d, want 5", h.GetActiveChannel("org:1"))
+	}
+	h.SetActiveChannel("org:1", 0)
+	if h.GetActiveChannel("org:1") != 0 {
+		t.Fatalf("active channel = %d, want 0", h.GetActiveChannel("org:1"))
+	}
+}
+
+func TestHubSendToUser(t *testing.T) {
+	h := NewHub()
+	c := mockConn(1, "org:1")
+	h.Register("org:1", c)
+	evt := Event{Type: "test", Payload: json.RawMessage(`{"msg":"hello"}`)}
+	h.SendToUser("org:1", evt)
+	select {
+	case data := <-c.send:
+		var e Event
+		if err := json.Unmarshal(data, &e); err != nil {
+			t.Fatal(err)
+		}
+		if e.Type != "test" {
+			t.Fatalf("type = %q, want test", e.Type)
+		}
+	default:
+		t.Fatal("expected message on send channel")
+	}
+}
+
+func TestHubSendToUser_MultiDevice(t *testing.T) {
+	h := NewHub()
+	c1 := mockConn(1, "org:1")
+	c2 := mockConn(1, "org:1")
+	h.Register("org:1", c1)
+	h.Register("org:1", c2)
+	evt := Event{Type: "broadcast", Payload: json.RawMessage(`{}`)}
+	h.SendToUser("org:1", evt)
+	// Both should receive
+	if len(c1.send) != 1 {
+		t.Fatal("c1 should have received message")
+	}
+	if len(c2.send) != 1 {
+		t.Fatal("c2 should have received message")
+	}
+}
+
+func TestHubSendToUser_NoConn(t *testing.T) {
+	h := NewHub()
+	// Should not panic
+	h.SendToUser("org:99", Event{Type: "test", Payload: json.RawMessage(`{}`)})
+}
+
+func TestHubOrgOnline(t *testing.T) {
+	h := NewHub()
+	h.Register("org1:1", mockConn(1, "org1:1"))
+	h.Register("org1:2", mockConn(2, "org1:2"))
+	h.Register("org2:1", mockConn(1, "org2:1"))
+	if n := h.OrgOnline("org1:"); n != 2 {
+		t.Fatalf("OrgOnline org1 = %d, want 2", n)
+	}
+	if n := h.OrgOnline("org2:"); n != 1 {
+		t.Fatalf("OrgOnline org2 = %d, want 1", n)
+	}
+	if n := h.OrgOnline("org3:"); n != 0 {
+		t.Fatalf("OrgOnline org3 = %d, want 0", n)
+	}
+}
+
+func TestHubOnlineKeys(t *testing.T) {
+	h := NewHub()
+	h.Register("a:1", mockConn(1, "a:1"))
+	h.Register("b:2", mockConn(2, "b:2"))
+	keys := h.OnlineKeys()
+	if len(keys) != 2 {
+		t.Fatalf("keys = %d, want 2", len(keys))
+	}
+}
+
+func TestConnSend_BufferFull(t *testing.T) {
+	c := &Conn{send: make(chan []byte, 1)}
+	c.Send([]byte("first"))
+	c.Send([]byte("dropped")) // buffer full, should not block
+	if len(c.send) != 1 {
+		t.Fatal("expected 1 message in buffer")
+	}
+}
+
+func TestHubUnregister_WrongConn(t *testing.T) {
+	h := NewHub()
+	c1 := mockConn(1, "org:1")
+	c2 := mockConn(1, "org:1")
+	h.Register("org:1", c1)
+	// Unregister a conn that was never registered
+	h.Unregister("org:1", c2)
+	// c1 should still be there
+	if !h.IsConnected("org:1") {
+		t.Fatal("c1 should still be connected")
+	}
+}
+
+func TestHubSetStatus_UnregisteredKey(t *testing.T) {
+	h := NewHub()
+	// Should not panic on unregistered key
+	h.SetStatus("nobody:1", "online")
+	if h.GetStatus("nobody:1") != "offline" {
+		t.Fatal("unregistered key should remain offline")
+	}
+}


### PR DESCRIPTION
Adds 37 unit tests covering 3 previously untested packages:

- **internal/auth** (0% → ~100%): JWT generate/validate, expired token, wrong secret, none signing method attack
- **internal/ws** (0% → ~90%): Hub register/unregister, multi-device, status logic, active channel, send-to-user, buffer full
- **internal/org** (0% → ~50%): Manager lifecycle, org registration, slug validation, token registry, default fallback, lazy init

All tests isolated (tempdir for org) and safe for parallel execution.