### PR TITLE
docs: add Release, Coverage, License badges

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,8 +1,11 @@
-[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Release](https://img.shields.io/github/v/release/getpusk/pusk)](https://github.com/getpusk/pusk/releases)
 [![CI](https://github.com/getpusk/pusk/actions/workflows/ci.yml/badge.svg)](https://github.com/getpusk/pusk/actions/workflows/ci.yml)
-[![Bot API](https://img.shields.io/badge/Telegram_Bot_API-13_methods-2CA5E0?logo=telegram)](https://core.telegram.org/bots/api)
-[![SQLite](https://img.shields.io/badge/SQLite-per_tenant-003B57?logo=sqlite)](https://www.sqlite.org)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/devitway/54c1b0a766ce24cb97ac0134c59212c7/raw/pusk-coverage.json)](https://github.com/getpusk/pusk/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/getpusk/pusk)](https://goreportcard.com/report/github.com/getpusk/pusk)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Bot API](https://img.shields.io/badge/Bot_API-13_methods-2CA5E0?logo=telegram)](https://core.telegram.org/bots/api)
+[![SQLite](https://img.shields.io/badge/SQLite-per_tenant-003B57?logo=sqlite)](https://www.sqlite.org)
 
 🌐 [Русский](README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Release](https://img.shields.io/github/v/release/getpusk/pusk)](https://github.com/getpusk/pusk/releases)
 [![CI](https://github.com/getpusk/pusk/actions/workflows/ci.yml/badge.svg)](https://github.com/getpusk/pusk/actions/workflows/ci.yml)
-[![Bot API](https://img.shields.io/badge/Telegram_Bot_API-13_methods-2CA5E0?logo=telegram)](https://core.telegram.org/bots/api)
-[![SQLite](https://img.shields.io/badge/SQLite-per_tenant-003B57?logo=sqlite)](https://www.sqlite.org)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/devitway/54c1b0a766ce24cb97ac0134c59212c7/raw/pusk-coverage.json)](https://github.com/getpusk/pusk/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/getpusk/pusk)](https://goreportcard.com/report/github.com/getpusk/pusk)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
+[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Bot API](https://img.shields.io/badge/Bot_API-13_methods-2CA5E0?logo=telegram)](https://core.telegram.org/bots/api)
+[![SQLite](https://img.shields.io/badge/SQLite-per_tenant-003B57?logo=sqlite)](https://www.sqlite.org)
 
 🌐 [English](README.en.md)
 


### PR DESCRIPTION
Adds Release version, Coverage (dynamic gist badge), and BSL 1.1 License badges to both README.md and README.en.md. Reorders badges: project info first, tech stack second.