### PR TITLE
test: coverage 44.7% → 47.4% (bot + api utilities)

### DIFF
--- a/internal/api/logging_test.go
+++ b/internal/api/logging_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ── normalizePath ──
+
+func TestNormalizePath_NoIDs(t *testing.T) {
+	if p := normalizePath("/api/health"); p != "/api/health" {
+		t.Errorf("got %q, want /api/health", p)
+	}
+}
+
+func TestNormalizePath_WithID(t *testing.T) {
+	if p := normalizePath("/api/channels/42/messages"); p != "/api/channels/{id}/messages" {
+		t.Errorf("got %q, want /api/channels/{id}/messages", p)
+	}
+}
+
+func TestNormalizePath_MultipleIDs(t *testing.T) {
+	if p := normalizePath("/admin/channel/5/msg/123"); p != "/admin/channel/{id}/msg/{id}" {
+		t.Errorf("got %q", p)
+	}
+}
+
+// ── statusWriter ──
+
+func TestStatusWriter_Default200(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: rec, code: http.StatusOK}
+	if sw.code != 200 {
+		t.Errorf("default code = %d, want 200", sw.code)
+	}
+}
+
+func TestStatusWriter_WriteHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: rec, code: http.StatusOK}
+	sw.WriteHeader(404)
+	if sw.code != 404 {
+		t.Errorf("code = %d, want 404", sw.code)
+	}
+	if rec.Code != 404 {
+		t.Errorf("underlying code = %d, want 404", rec.Code)
+	}
+}
+
+func TestStatusWriter_Hijack_NotSupported(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: rec, code: http.StatusOK}
+	_, _, err := sw.Hijack()
+	if err == nil {
+		t.Error("expected error from Hijack on non-hijackable writer")
+	}
+}
+
+// ── RequestLogger ──
+
+func TestRequestLogger_SetsStatusCode(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+	})
+	logged := RequestLogger(handler)
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	rec := httptest.NewRecorder()
+	logged.ServeHTTP(rec, req)
+	if rec.Code != 201 {
+		t.Errorf("code = %d, want 201", rec.Code)
+	}
+}
+
+func TestRequestLogger_PassesThrough(t *testing.T) {
+	called := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(200)
+	})
+	logged := RequestLogger(handler)
+	req := httptest.NewRequest("POST", "/api/auth", nil)
+	rec := httptest.NewRecorder()
+	logged.ServeHTTP(rec, req)
+	if !called {
+		t.Error("handler should be called")
+	}
+}
+
+// ── truncateText ──
+
+func TestTruncateText_Short(t *testing.T) {
+	if s := truncateText("hello", 10); s != "hello" {
+		t.Errorf("got %q", s)
+	}
+}
+
+func TestTruncateText_Exact(t *testing.T) {
+	if s := truncateText("hello", 5); s != "hello" {
+		t.Errorf("got %q", s)
+	}
+}
+
+func TestTruncateText_Long(t *testing.T) {
+	s := truncateText("hello world", 5)
+	if s != "hello..." {
+		t.Errorf("got %q, want hello...", s)
+	}
+}

--- a/internal/bot/relay_extra_test.go
+++ b/internal/bot/relay_extra_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package bot
+
+import (
+	"testing"
+
+	"github.com/pusk-platform/pusk/internal/ws"
+)
+
+func TestRelayHub_Register(t *testing.T) {
+	rh := NewRelayHub()
+	c := ws.NewConn(nil, 0)
+	rh.Register(1, c)
+
+	if !rh.IsConnected(1) {
+		t.Error("bot 1 should be connected after Register")
+	}
+	if rh.Online() != 1 {
+		t.Errorf("expected 1 online, got %d", rh.Online())
+	}
+}
+
+func TestRelayHub_Register_ReplacesOld(t *testing.T) {
+	rh := NewRelayHub()
+	c1 := ws.NewConn(nil, 0)
+	c2 := ws.NewConn(nil, 0)
+
+	rh.Register(1, c1)
+	rh.Register(1, c2) // should replace c1
+
+	if rh.Online() != 1 {
+		t.Errorf("expected 1 online after replace, got %d", rh.Online())
+	}
+	// Old conn should have received "replaced" message
+	rh.mu.RLock()
+	cur := rh.conns[1]
+	rh.mu.RUnlock()
+	if cur != c2 {
+		t.Error("expected c2 to be current connection")
+	}
+}
+
+func TestRelayHub_Unregister(t *testing.T) {
+	rh := NewRelayHub()
+	c := ws.NewConn(nil, 0)
+	rh.Register(1, c)
+	rh.Unregister(1, c)
+
+	if rh.IsConnected(1) {
+		t.Error("bot 1 should be disconnected after Unregister")
+	}
+	if rh.Online() != 0 {
+		t.Errorf("expected 0 online, got %d", rh.Online())
+	}
+}
+
+func TestRelayHub_Unregister_WrongConn(t *testing.T) {
+	rh := NewRelayHub()
+	c1 := ws.NewConn(nil, 0)
+	c2 := ws.NewConn(nil, 0)
+	rh.Register(1, c1)
+	rh.Unregister(1, c2) // wrong conn, should NOT unregister
+
+	if !rh.IsConnected(1) {
+		t.Error("bot 1 should still be connected (wrong conn)")
+	}
+}
+
+func TestRelayHub_Send_Connected(t *testing.T) {
+	rh := NewRelayHub()
+	c := ws.NewConn(nil, 0)
+	rh.Register(1, c)
+
+	if !rh.Send(1, map[string]string{"type": "test"}) {
+		t.Error("Send to connected bot should return true")
+	}
+}
+
+func TestRelayHub_MultipleBotsIndependent(t *testing.T) {
+	rh := NewRelayHub()
+	c1 := ws.NewConn(nil, 0)
+	c2 := ws.NewConn(nil, 0)
+	rh.Register(1, c1)
+	rh.Register(2, c2)
+
+	if rh.Online() != 2 {
+		t.Errorf("expected 2 online, got %d", rh.Online())
+	}
+
+	rh.Unregister(1, c1)
+	if rh.Online() != 1 {
+		t.Errorf("expected 1 online after partial unregister, got %d", rh.Online())
+	}
+	if !rh.IsConnected(2) {
+		t.Error("bot 2 should still be connected")
+	}
+}

--- a/internal/bot/route_test.go
+++ b/internal/bot/route_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package bot
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// ── botIPFromRequest ──
+
+func TestBotIPFromRequest_Direct(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.5:12345"
+	ip := botIPFromRequest(req)
+	if ip != "203.0.113.5" {
+		t.Errorf("ip = %q, want 203.0.113.5", ip)
+	}
+}
+
+func TestBotIPFromRequest_LoopbackWithXFF(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("X-Forwarded-For", "198.51.100.1, 203.0.113.2")
+	ip := botIPFromRequest(req)
+	if ip != "198.51.100.1" {
+		t.Errorf("ip = %q, want 198.51.100.1 (first XFF)", ip)
+	}
+}
+
+func TestBotIPFromRequest_PublicIgnoresXFF(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.5:12345"
+	req.Header.Set("X-Forwarded-For", "198.51.100.1")
+	ip := botIPFromRequest(req)
+	if ip != "203.0.113.5" {
+		t.Errorf("ip = %q, want 203.0.113.5 (public ignores XFF)", ip)
+	}
+}
+
+// ── checkBotAuthRL ──
+
+func TestCheckBotAuthRL_NoFailures(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "198.51.100.50:1234"
+	if checkBotAuthRL(req, "unique-tok-nofail") {
+		t.Error("should not be rate limited with no failures")
+	}
+}
+
+func TestCheckBotAuthRL_UnderLimit(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "198.51.100.51:1234"
+	req.Header.Set("X-Bot-Token", "under-limit-tok")
+	for i := 0; i < 10; i++ {
+		trackBotAuthFail(req)
+	}
+	if checkBotAuthRL(req, "under-limit-tok") {
+		t.Error("should not be rate limited under 50 failures")
+	}
+}
+
+// ── trackBotAuthFail ──
+
+func TestTrackBotAuthFail_Records(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "198.51.100.52:1234"
+	req.Header.Set("X-Bot-Token", "track-fail-tok")
+	trackBotAuthFail(req)
+	// Should not panic and should record
+	if checkBotAuthRL(req, "track-fail-tok") {
+		t.Error("single failure should not trigger rate limit")
+	}
+}
+
+// ── webhookAllowed ──
+
+func TestWebhookAllowed_FirstCall(t *testing.T) {
+	if !webhookAllowed("unique-webhook-tok-1") {
+		t.Error("first call should be allowed")
+	}
+}
+
+func TestWebhookAllowed_UnderLimit(t *testing.T) {
+	tok := "under-limit-webhook-tok"
+	for i := 0; i < 10; i++ {
+		if !webhookAllowed(tok) {
+			t.Errorf("call %d should be allowed", i)
+		}
+	}
+}
+
+// ── truncateStr ──
+
+func TestTruncateStr_Short(t *testing.T) {
+	if s := truncateStr("hello", 10); s != "hello" {
+		t.Errorf("got %q, want hello", s)
+	}
+}
+
+func TestTruncateStr_Exact(t *testing.T) {
+	if s := truncateStr("hello", 5); s != "hello" {
+		t.Errorf("got %q, want hello", s)
+	}
+}
+
+func TestTruncateStr_Long(t *testing.T) {
+	s := truncateStr("hello world", 5)
+	if s != "hello..." {
+		t.Errorf("got %q, want hello...", s)
+	}
+}
+
+func TestTruncateStr_Unicode(t *testing.T) {
+	s := truncateStr("привет мир", 6)
+	if s != "привет..." {
+		t.Errorf("got %q, want привет...", s)
+	}
+}


### PR DESCRIPTION
## Summary
- 29 new unit tests for bot and api utility functions
- relay Register/Unregister/Replace/Send, botIPFromRequest, checkBotAuthRL
- trackBotAuthFail, webhookAllowed, truncateStr, normalizePath
- statusWriter, RequestLogger, truncateText

## Metrics
| Metric | Before | After |
|--------|--------|-------|
| Tests | 266 | 295 |
| Coverage | 44.7% | 47.4% |
| Bot pkg | 28.8% | 35.1% |
| API pkg | 35.3% | 36.9% |