### PR TITLE
chore: DX and lint improvements

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,16 @@
+# Bulk format/lint commits — ignore in git blame
+
+# Lint: gofmt, staticcheck clean, use http status constants
+4104d4400363a3f15c93b89b8ff1ff153d7eb9e6
+
+# CI: add staticcheck + gofmt check
+1493f5c1977d615525fbef61f876777ea5000aaa
+
+# lint: add golangci-lint config, fix all errcheck and staticcheck issues
+36fa35e7322e5124a99e3ad355e1d71e35453130
+
+# fix: golangci-lint v2 config
+86449d55e868b16250097220caf7cbf0d3557312
+
+# Code review: fix all 12 issues (CSS cleanup, auth styles, dead code, Russian UI, security fixes)
+ec28ce8f2214c815abb1cc157b43f2a5fcde1207

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## What
+
+<!-- Brief description of changes -->
+
+## Why
+
+<!-- Motivation / issue reference -->
+
+## Checklist
+
+- [ ] Tests pass (`go test ./...`)
+- [ ] No lint warnings (`golangci-lint run`)
+- [ ] Updated CHANGELOG.md (if user-facing)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
 permissions: read-all
 
 jobs:
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: crate-ci/typos@11855fae979c9b0ab4c6962bc9e7cc8e10aa3de0 # v1.31.1
+
   build:
     name: Build & Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: crate-ci/typos@11855fae979c9b0ab4c6962bc9e7cc8e10aa3de0 # v1.31.1
+      - uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1.45.0
 
   build:
     name: Build & Lint

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,4 +2,12 @@
 extend-exclude = ["vendor/", "go.sum", "*.lock"]
 
 [default.extend-words]
-# False positives common in Go projects
+# Minified JS variable names
+pn = "pn"
+# Test fixture slug
+nodel = "nodel"
+# Test bot name prefix
+ot = "ot"
+# Lint script: "ERRORs" and "WARNINGs" (typos splits plural forms)
+ERRO = "ERRO"
+WARNIN = "WARNIN"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,5 @@
+[files]
+extend-exclude = ["vendor/", "go.sum", "*.lock"]
+
+[default.extend-words]
+# False positives common in Go projects

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -237,7 +237,7 @@ func unwrapMarkup(raw json.RawMessage) string {
 // isHex reports whether s contains only hexadecimal characters.
 func isHex(s string) bool {
 	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
 			return false
 		}
 	}

--- a/internal/bot/webhook.go
+++ b/internal/bot/webhook.go
@@ -258,13 +258,13 @@ func formatZabbix(p map[string]interface{}) string {
 		icon = "Resolved"
 	}
 
-	sb.WriteString(fmt.Sprintf("**%s** %s", icon, subject))
+	fmt.Fprintf(&sb, "**%s** %s", icon, subject)
 	if severity != "" {
-		sb.WriteString(fmt.Sprintf(" [%s]", severity))
+		fmt.Fprintf(&sb, " [%s]", severity)
 	}
 	sb.WriteString("\n")
 	if host != "" {
-		sb.WriteString(fmt.Sprintf("Host: *%s*\n", host))
+		fmt.Fprintf(&sb, "Host: *%s*\n", host)
 	}
 	if message != "" {
 		sb.WriteString(message + "\n")
@@ -303,9 +303,9 @@ func formatGrafana(p map[string]interface{}) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("**%s** %s", icon, name))
+	fmt.Fprintf(&sb, "**%s** %s", icon, name)
 	if state != "" {
-		sb.WriteString(fmt.Sprintf(" [%s]", state))
+		fmt.Fprintf(&sb, " [%s]", state)
 	}
 	sb.WriteString("\n")
 	if message != "" {

--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -154,7 +154,7 @@ func (m *Manager) Register(slug, name, adminUser, adminPin string) error {
 		return fmt.Errorf("slug must be 2-32 characters")
 	}
 	for _, c := range slug {
-		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-' {
 			return fmt.Errorf("slug must contain only lowercase letters, digits and hyphens")
 		}
 	}


### PR DESCRIPTION
## Summary

- Add typos spell-check job to CI (crate-ci/typos v1.31.1) with `_typos.toml` config
- Add `.git-blame-ignore-revs` to skip bulk fmt/lint commits in git blame
- Add PR template with checklist (tests, lint, changelog)
- Fix style lint: replace `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf` in webhook formatters (5 places)
- Fix style lint: apply De Morgan simplification in `isHex()` and org slug validator

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` clean
- [x] `gofumpt -l .` clean
- [x] `golangci-lint run` clean
- [x] `staticcheck ./...` clean
- [x] Pre-commit hooks pass on all commits