### PR TITLE
feat: exclude demo code from release binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Build Pusk
         run: |
           VER=$(git describe --tags --always 2>/dev/null || echo "ci")
-          go build -ldflags "-X github.com/pusk-platform/pusk/internal/api.Version=$VER" -o pusk ./cmd/pusk/
+          go build -tags demo -ldflags "-X github.com/pusk-platform/pusk/internal/api.Version=$VER" -o pusk ./cmd/pusk/
 
       - name: Start Pusk
         run: |
@@ -178,7 +178,7 @@ jobs:
       - name: Build Pusk
         run: |
           VER=$(git describe --tags --always 2>/dev/null || echo "ci")
-          go build -ldflags "-X github.com/pusk-platform/pusk/internal/api.Version=$VER" -o pusk ./cmd/pusk/
+          go build -tags demo -ldflags "-X github.com/pusk-platform/pusk/internal/api.Version=$VER" -o pusk ./cmd/pusk/
 
       - name: Start Pusk
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 LDFLAGS = -X github.com/pusk-platform/pusk/internal/api.Version=$(VERSION)
 BINARY = pusk
 
-.PHONY: build run test lint deploy
+.PHONY: build run test lint build-demo deploy
 
 build:
 	go build -o $(BINARY) -ldflags "$(LDFLAGS)" ./cmd/pusk/
 	@echo "Built $(BINARY) $(VERSION)"
+
+build-demo:
+	go build -tags demo -o $(BINARY) -ldflags "$(LDFLAGS)" ./cmd/pusk/
+	@echo "Built $(BINARY) $(VERSION) [demo]"
 
 run: build
 	./$(BINARY)

--- a/cmd/pusk/demo.go
+++ b/cmd/pusk/demo.go
@@ -1,3 +1,5 @@
+//go:build demo
+
 // Copyright (c) 2026 Volkov Pavel | DevITWay
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 package main

--- a/cmd/pusk/demo_stub.go
+++ b/cmd/pusk/demo_stub.go
@@ -1,0 +1,9 @@
+//go:build !demo
+
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package main
+
+import "github.com/pusk-platform/pusk/internal/store"
+
+func initDemo(_ *store.Store) {}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -44,7 +44,7 @@ else
   echo "  All checks passed (remote)."
 fi
 
-# --- Build ---
+# --- Build (release, NO -tags demo — clean binary without demo code) ---
 echo "[1/6] Building..."
 if [ -f go.mod ]; then
   CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/pusk-platform/pusk/internal/api.Version=$VER" \

--- a/scripts/lint-pusk.sh
+++ b/scripts/lint-pusk.sh
@@ -135,6 +135,24 @@ for f in $GO_FILES; do
     fi
 done
 
+# ─── Build Tag Guards ────────────────────────────────────────
+
+echo "[lint-pusk] Build tag guards..."
+
+# 7. demo.go must have //go:build demo tag
+if [ -f cmd/pusk/demo.go ]; then
+    if ! head -1 cmd/pusk/demo.go | grep -q "^//go:build demo"; then
+        err "cmd/pusk/demo.go missing //go:build demo tag — demo code must not leak into release binary"
+    fi
+fi
+
+# 8. demo_stub.go must have //go:build !demo tag
+if [ -f cmd/pusk/demo_stub.go ]; then
+    if ! head -1 cmd/pusk/demo_stub.go | grep -q "^//go:build !demo"; then
+        err "cmd/pusk/demo_stub.go missing //go:build !demo tag"
+    fi
+fi
+
 # ─── Summary ─────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary
- Demo code (`demo.go`) now requires `-tags demo` build tag to compile
- Release builds get a no-op `demo_stub.go` stub — zero demo code in binary
- `docker run ghcr.io/getpusk/pusk` is now a clean Pusk instance
- CI integration/e2e tests build with `-tags demo` as before

## Changes
- `cmd/pusk/demo.go` — added `//go:build demo`
- `cmd/pusk/demo_stub.go` — new, `//go:build !demo`, no-op `initDemo()`
- `Makefile` — added `build-demo` target
- `.github/workflows/ci.yml` — integration + e2e build with `-tags demo`
- `scripts/lint-pusk.sh` — build tag guard (catches accidental tag removal)
- `scripts/deploy.sh` — explicit comment about no-demo build

## Test plan
- [x] `go build ./cmd/pusk/` compiles (release, no demo)
- [x] `go build -tags demo ./cmd/pusk/` compiles (demo)
- [x] `go vet ./...` passes both variants
- [x] `strings` on release binary shows no demo tokens/users
- [x] lint-pusk.sh catches missing build tag (negative test, exit 1)
- [x] check.sh verifies both build variants