### PR TITLE
fix: patch alpine CVE-2026-28390, CVE-2026-22184

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION=dev
 RUN CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/pusk-platform/pusk/internal/api.Version=${VERSION}" -o pusk ./cmd/pusk/
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache upgrade && apk --no-cache add ca-certificates
 WORKDIR /app
 COPY --from=builder /build/pusk .
 COPY --from=builder /build/web/static ./web/static

--- a/Dockerfile.astra
+++ b/Dockerfile.astra
@@ -3,7 +3,7 @@
 # Binary is pre-built by CI (go build, CGO_ENABLED=0) and passed via context
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS certs
-RUN apk add --no-cache ca-certificates \
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates \
     && addgroup -S -g 10001 pusk && adduser -S -u 10001 -G pusk pusk
 
 FROM scratch

--- a/Dockerfile.redos
+++ b/Dockerfile.redos
@@ -3,7 +3,7 @@
 # Binary is pre-built by CI (go build, CGO_ENABLED=0) and passed via context
 
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS certs
-RUN apk add --no-cache ca-certificates \
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates \
     && addgroup -S -g 10001 pusk && adduser -S -u 10001 -G pusk pusk
 
 FROM scratch


### PR DESCRIPTION
## Summary
- `apk upgrade --no-cache` before `apk add` in all 3 Dockerfiles
- Fixes 3 HIGH CVEs in alpine 3.23 base image:
  - **CVE-2026-28390**: OpenSSL DoS via NULL pointer dereference in CMS (libcrypto3/libssl3 3.5.5 → 3.5.6)
  - **CVE-2026-22184**: zlib buffer overflow in untgz utility (1.3.1 → 1.3.2)
- Trivy scan blocked v0.7.1 release due to these

## Test plan
- [x] `apk upgrade` locally confirms packages update
- [ ] CI Trivy scan passes with 0 HIGH/CRITICAL