### PR TITLE
chore: bump Go 1.26.0 → 1.26.2 (security fixes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS builder
+FROM golang:1.26-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pusk-platform/pusk
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0


### PR DESCRIPTION
## Summary
- Update Go from 1.26.0 to 1.26.2 (released 2026-04-07)
- Pin golang Docker builder image to 1.26.2 digest
- Fixes 7 Go stdlib CVEs (crypto/tls, crypto/x509, os, archive/tar, html/template) that caused Trivy scan failures in v0.7.2 release

## Motivation
v0.7.2 release pipeline blocked by Trivy: Go stdlib MEDIUM/UNKNOWN CVEs in 1.26.1. Proper fix = update Go, not ignore.