### PR TITLE
fix: webhook URL leak + silent alert loss

### DIFF
--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -453,7 +454,12 @@ func (h *Handler) setWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = h.db(r).SetWebhook(bot.ID, req.URL)
-	slog.Info("webhook set", "bot", bot.Name, "url", req.URL)
+	// Log only host to avoid leaking credentials in webhook URLs
+	logURL := req.URL
+	if u, err := url.Parse(req.URL); err == nil {
+		logURL = u.Host
+	}
+	slog.Info("webhook set", "bot", bot.Name, "host", logURL)
 	jsonResp(w, 200, APIResponse{OK: true, Result: true})
 }
 

--- a/internal/bot/webhook.go
+++ b/internal/bot/webhook.go
@@ -160,6 +160,9 @@ func (h *Handler) webhook(w http.ResponseWriter, r *http.Request) {
 	msg, err := s.SaveChannelMessage(ch.ID, text, markup, "", "")
 	if err != nil {
 		slog.Error("webhook save failed", "error", err)
+		w.WriteHeader(500)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "error", "error": "save failed"})
+		return
 	}
 
 	// Push to subscribers via WebSocket (reuse existing push logic)


### PR DESCRIPTION
## Summary
- **handler.go**: Log only host portion of webhook URL to prevent credential leakage in structured logs
- **webhook.go**: Return HTTP 500 when SaveChannelMessage fails instead of silently returning 200 (prevents alert loss)

## Test plan
- [x] All existing tests pass (299/299)
- [x] go build clean
- [ ] Verify webhook endpoint returns 500 on DB failure
- [ ] Verify logs no longer contain full webhook URLs