### PR TITLE
feat: self-hosted security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Start Pusk
         run: |
-          PUSK_DEMO=1 PUSK_ADDR=:9999 ./pusk &
+          PUSK_DEMO=1 PUSK_MAX_ORGS=0 PUSK_ADDR=:9999 ./pusk &
           for i in $(seq 1 10); do
             curl -sf http://localhost:9999/api/health && break || sleep 1
           done
@@ -182,7 +182,7 @@ jobs:
 
       - name: Start Pusk
         run: |
-          PUSK_DEMO=1 PUSK_ADDR=:9999 ./pusk &
+          PUSK_DEMO=1 PUSK_MAX_ORGS=0 PUSK_ADDR=:9999 ./pusk &
           for i in $(seq 1 10); do
             curl -sf http://localhost:9999/api/health && break || sleep 1
           done

--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -69,6 +69,16 @@ func main() {
 	}
 	defer orgs.Close()
 
+	// Org creation limit (default: 1 user-created org; 0 = unlimited)
+	maxOrgs := 1
+	if v := os.Getenv("PUSK_MAX_ORGS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			maxOrgs = n
+		}
+	}
+	orgs.MaxOrgs = maxOrgs
+	slog.Info("org limit configured", "max_orgs", maxOrgs)
+
 	// Default org store (backwards compatible)
 	db, err := orgs.Get("default")
 	if err != nil {
@@ -101,6 +111,9 @@ func main() {
 	jwtSvc := auth.NewJWTService(jwtSecret, 168) // 7 days
 
 	adminToken := os.Getenv("PUSK_ADMIN_TOKEN")
+	if adminToken == "" {
+		slog.Warn("PUSK_ADMIN_TOKEN not set — org creation is unprotected, set it for production use")
+	}
 
 	mux := http.NewServeMux()
 
@@ -110,6 +123,10 @@ func main() {
 
 	// Client API (for PWA)
 	clientAPI := api.NewClientAPI(orgs, db, hub, push, botHandler.Relay(), botHandler.Updates(), vapidPub, jwtSvc)
+	if os.Getenv("PUSK_OPEN_USER_REGISTRATION") == "false" {
+		clientAPI.OpenUserReg = false
+		slog.Info("user self-registration disabled, invite required")
+	}
 	clientAPI.Route(mux)
 
 	// Admin API (admin endpoints + org registration)

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -41,6 +41,7 @@ func (a *AdminAPI) Route(mux *http.ServeMux) {
 	mux.HandleFunc("POST /admin/set-role", a.adminSetRole)
 
 	orgRL := NewRateLimiter(10, time.Minute)
+	mux.HandleFunc("GET /api/org/info", a.orgInfo)
 	mux.HandleFunc("POST /api/org/register", RateLimit(orgRL, a.registerOrg))
 }
 
@@ -260,7 +261,41 @@ func (a *AdminAPI) renameBot(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
 }
 
+func (a *AdminAPI) isGlobalAdmin(r *http.Request) bool {
+	if a.adminToken == "" {
+		return false
+	}
+	authHeader := r.Header.Get("Authorization")
+	return subtle.ConstantTimeCompare(
+		[]byte(strings.TrimPrefix(authHeader, "Bearer ")),
+		[]byte(a.adminToken),
+	) == 1
+}
+
+func (a *AdminAPI) orgInfo(w http.ResponseWriter, r *http.Request) {
+	orgs := a.orgs.List()
+	userOrgs := 0
+	for _, o := range orgs {
+		if o.Slug != "default" {
+			userOrgs++
+		}
+	}
+	canCreate := a.orgs.CanCreateOrg()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"can_create_org": canCreate,
+		"count":          userOrgs,
+		"max":            a.orgs.MaxOrgs,
+	})
+}
+
 func (a *AdminAPI) registerOrg(w http.ResponseWriter, r *http.Request) {
+	// Enforce org limit unless caller has admin token
+	if !a.orgs.CanCreateOrg() && !a.isGlobalAdmin(r) {
+		jsonErr(w, "org registration disabled — limit reached", http.StatusForbidden)
+		return
+	}
+
 	var req struct {
 		Slug     string `json:"slug"`
 		Name     string `json:"name"`
@@ -275,8 +310,8 @@ func (a *AdminAPI) registerOrg(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"slug, username and pin required"}`, 400)
 		return
 	}
-	if len(req.Pin) < 6 {
-		http.Error(w, `{"error":"password must be at least 6 characters"}`, 400)
+	if len(req.Pin) < 8 {
+		http.Error(w, `{"error":"password must be at least 8 characters"}`, 400)
 		return
 	}
 	if err := a.orgs.Register(req.Slug, req.Name, req.Username, req.Pin); err != nil {
@@ -318,8 +353,8 @@ func (a *AdminAPI) resetPassword(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"org, username and new_pin required"}`, 400)
 		return
 	}
-	if len(req.NewPin) < 6 {
-		http.Error(w, `{"error":"password must be at least 6 characters"}`, 400)
+	if len(req.NewPin) < 8 {
+		http.Error(w, `{"error":"password must be at least 8 characters"}`, 400)
 		return
 	}
 	s, err := a.orgs.Get(req.Org)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -27,18 +27,19 @@ var upgrader = websocket.Upgrader{
 
 // ClientAPI handles PWA client requests
 type ClientAPI struct {
-	orgs     *org.Manager
-	store    *store.Store
-	hub      *ws.Hub
-	push     *notify.PushService
-	relay    *bot.RelayHub
-	updates  *bot.UpdateQueue
-	vapidPub string
-	jwt      *auth.JWTService
+	orgs        *org.Manager
+	store       *store.Store
+	hub         *ws.Hub
+	push        *notify.PushService
+	relay       *bot.RelayHub
+	updates     *bot.UpdateQueue
+	vapidPub    string
+	jwt         *auth.JWTService
+	OpenUserReg bool // allow self-registration on default org (default true)
 }
 
 func NewClientAPI(orgs *org.Manager, s *store.Store, hub *ws.Hub, push *notify.PushService, relay *bot.RelayHub, updates *bot.UpdateQueue, vapidPub string, jwtSvc *auth.JWTService) *ClientAPI {
-	return &ClientAPI{orgs: orgs, store: s, hub: hub, push: push, relay: relay, updates: updates, vapidPub: vapidPub, jwt: jwtSvc}
+	return &ClientAPI{orgs: orgs, store: s, hub: hub, push: push, relay: relay, updates: updates, vapidPub: vapidPub, jwt: jwtSvc, OpenUserReg: true}
 }
 
 // db returns the Store for the org derived from JWT claims in context.

--- a/internal/api/client_auth.go
+++ b/internal/api/client_auth.go
@@ -114,6 +114,11 @@ func (a *ClientAPI) auth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *ClientAPI) register(w http.ResponseWriter, r *http.Request) {
+	if !a.OpenUserReg {
+		jsonErr(w, "registration disabled, ask admin for invite", http.StatusForbidden)
+		return
+	}
+
 	var req struct {
 		Username    string `json:"username"`
 		Pin         string `json:"pin"`
@@ -145,8 +150,8 @@ func (a *ClientAPI) register(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "username must be 2-32 characters (letters, digits, _ or -)", 400)
 		return
 	}
-	if len(req.Pin) < 6 {
-		jsonErr(w, "password must be at least 6 characters", 400)
+	if len(req.Pin) < 8 {
+		jsonErr(w, "password must be at least 8 characters", 400)
 		return
 	}
 
@@ -231,8 +236,8 @@ func (a *ClientAPI) acceptInvite(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "username must be 2-32 characters (letters, digits, _ or -)", 400)
 		return
 	}
-	if len(req.Pin) < 6 {
-		jsonErr(w, "password must be at least 6 characters", 400)
+	if len(req.Pin) < 8 {
+		jsonErr(w, "password must be at least 8 characters", 400)
 		return
 	}
 
@@ -417,8 +422,8 @@ func (a *ClientAPI) changePassword(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "old_pin and new_pin required", 400)
 		return
 	}
-	if len(req.NewPin) < 6 {
-		jsonErr(w, "password must be at least 6 characters", 400)
+	if len(req.NewPin) < 8 {
+		jsonErr(w, "password must be at least 8 characters", 400)
 		return
 	}
 	claims := ClaimsFromCtx(r.Context())

--- a/internal/api/client_chat.go
+++ b/internal/api/client_chat.go
@@ -286,5 +286,6 @@ func (a *ClientAPI) health(w http.ResponseWriter, r *http.Request) {
 		"version": Version,
 		"db":      dbOK,
 		"uptime":  time.Since(startTime).Truncate(time.Second).String(),
+		"orgs":    len(a.orgs.List()),
 	})
 }

--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -33,6 +33,7 @@ type Manager struct {
 	dir      string  // data/orgs/
 	masterFn string  // data/master.json
 	tokDB    *sql.DB // global token→org mapping
+	MaxOrgs  int     // 0 = unlimited, default 1
 }
 
 func NewManager(dataDir string) (*Manager, error) {
@@ -173,6 +174,11 @@ func (m *Manager) Register(slug, name, adminUser, adminPin string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Enforce org limit (default org doesn't count toward the limit)
+	if m.MaxOrgs > 0 && m.userOrgCount() >= m.MaxOrgs {
+		return fmt.Errorf("max organizations limit reached (%d)", m.MaxOrgs)
+	}
+
 	if m.hasOrg(slug) {
 		return fmt.Errorf("org already exists: %s", slug)
 	}
@@ -262,6 +268,28 @@ func (m *Manager) List() []Org {
 	out := make([]Org, len(m.orgs))
 	copy(out, m.orgs)
 	return out
+}
+
+// userOrgCount returns the number of user-created orgs (excludes "default").
+// Must be called with mu held.
+func (m *Manager) userOrgCount() int {
+	count := 0
+	for _, o := range m.orgs {
+		if o.Slug != "default" {
+			count++
+		}
+	}
+	return count
+}
+
+// CanCreateOrg reports whether a new org can be created within the limit.
+func (m *Manager) CanCreateOrg() bool {
+	if m.MaxOrgs <= 0 {
+		return true
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.userOrgCount() < m.MaxOrgs
 }
 
 // Close closes all open stores

--- a/web/static/js/landing.js
+++ b/web/static/js/landing.js
@@ -68,6 +68,12 @@ $('btn-reg').onclick=async()=>{const u=$('a-user').value.trim(),p=$('a-pin').val
 $('btn-demo').onclick=async()=>{let r=await api('POST','/api/auth',{username:'guest',pin:'guest'});if(!r.token)r=await api('POST','/api/register',{username:'guest',pin:'guest',display_name:'Guest'});if(!r.token){$('a-err').textContent=t('err_demo');return}S.token=r.token;S.isDemo=true;hideLanding();$('auth').style.display='none';showApp()};
 
 // ── Org creation ──
+// Hide "Create org" button when limit reached
+fetch('/api/org/info').then(r=>r.json()).then(d=>{
+  if(d&&d.can_create_org===false){
+    const btn=$('land-create-org');if(btn)btn.style.display='none';
+  }
+}).catch(()=>{});
 $('land-create-org').onclick=()=>{$('org-modal-bg').classList.add('open');$('org-slug').focus()};
 $('org-cancel').onclick=()=>$('org-modal-bg').classList.remove('open');
 $('org-to-login').onclick=(e)=>{e.preventDefault();$('org-modal-bg').classList.remove('open');hideLanding();$('auth').style.display='flex';const savedOrg=get('org');if(savedOrg)$('a-org').value=savedOrg};


### PR DESCRIPTION
## Summary

- Increase minimum password length from 6 to 8 characters
- Add `PUSK_MAX_ORGS` env (default 1) to limit org creation per instance
- Add `PUSK_OPEN_USER_REGISTRATION` env to disable self-registration
- Add `GET /api/org/info` endpoint for org limit status
- Enforce org limit in org registration (admin token bypasses)
- Hide "Create organization" button in PWA when limit reached
- Log warning on startup when `PUSK_ADMIN_TOKEN` is not set
- Include org count in `/api/health` response

## Motivation

When someone installs Pusk on a VPS, the instance is open by default — anyone can create organizations and brute-force passwords. This PR adds secure-by-default configuration: org creation is limited to 1, and admin token holders can bypass limits.

## New environment variables

| Variable | Default | Description |
|----------|---------|-------------|
| `PUSK_MAX_ORGS` | `1` | Max user-created orgs (0 = unlimited) |
| `PUSK_OPEN_USER_REGISTRATION` | `true` | Set `false` to require invite links |
| `PUSK_ADMIN_TOKEN` | (empty) | Bypasses org limit, enables admin endpoints |

## Test plan

- [ ] Create org without admin token — succeeds (first org)
- [ ] Create second org without admin token — returns 403
- [ ] Create org with admin token — bypasses limit
- [ ] Register with 7-char password — returns 400
- [ ] Register with 8-char password — succeeds
- [ ] Set `PUSK_OPEN_USER_REGISTRATION=false`, try register — returns 403
- [ ] Verify `/api/org/info` returns correct `can_create_org` flag
- [ ] Verify `/api/health` includes `orgs` count
- [ ] Verify landing page hides "Create org" button when limit reached