### PR TITLE
fix: demo visibility, org modal reset, auth UX

### DIFF
--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -147,6 +147,9 @@ func main() {
 		clientAPI.OpenUserReg = false
 		slog.Info("user self-registration disabled, invite required")
 	}
+	if os.Getenv("PUSK_DEMO") == "1" {
+		clientAPI.DemoMode = true
+	}
 	clientAPI.Route(mux)
 
 	// Admin API (admin endpoints + org registration)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -36,6 +36,7 @@ type ClientAPI struct {
 	vapidPub    string
 	jwt         *auth.JWTService
 	OpenUserReg bool // allow self-registration on default org (default true)
+	DemoMode    bool // PUSK_DEMO=1 active
 }
 
 func NewClientAPI(orgs *org.Manager, s *store.Store, hub *ws.Hub, push *notify.PushService, relay *bot.RelayHub, updates *bot.UpdateQueue, vapidPub string, jwtSvc *auth.JWTService) *ClientAPI {

--- a/internal/api/client_chat.go
+++ b/internal/api/client_chat.go
@@ -287,5 +287,6 @@ func (a *ClientAPI) health(w http.ResponseWriter, r *http.Request) {
 		"db":      dbOK,
 		"uptime":  time.Since(startTime).Truncate(time.Second).String(),
 		"orgs":    len(a.orgs.List()),
+		"demo":    a.DemoMode,
 	})
 }

--- a/web/static/js/landing.js
+++ b/web/static/js/landing.js
@@ -77,7 +77,9 @@ fetch('/api/org/info').then(r=>r.json()).then(d=>{
     const lnk=$('org-to-login');if(lnk)lnk.style.display='none';
   }
 }).catch(()=>{});
-$('land-create-org').onclick=()=>{$('org-modal-bg').classList.add('open');$('org-slug').focus()};
+fetch('/api/health').then(r=>r.json()).then(d=>{if(!d||!d.demo){const db=$('land-demo');if(db)db.style.display='none';const rp=document.querySelector('.land-right');if(rp)rp.style.display='none'}}).catch(()=>{});
+if(get('token')){const lnk=$('org-to-login');if(lnk)lnk.style.display='none'}
+$('land-create-org').onclick=()=>{$('org-slug').value='';$('org-name').value='';$('org-user').value='';$('org-pin').value='';$('org-msg').textContent='';$('org-modal-bg').classList.add('open');$('org-slug').focus()};
 $('org-cancel').onclick=()=>$('org-modal-bg').classList.remove('open');
 $('org-to-login').onclick=(e)=>{e.preventDefault();$('org-modal-bg').classList.remove('open');hideLanding();$('auth').style.display='flex';const savedOrg=get('org');if(savedOrg)$('a-org').value=savedOrg};
 $('org-modal-bg').onclick=e=>{if(e.target===$('org-modal-bg'))$('org-modal-bg').classList.remove('open')};

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -1,5 +1,5 @@
 // Pusk Service Worker — App Shell cache + Push notifications
-const CACHE = 'pusk-v84';
+const CACHE = 'pusk-v86';
 const SHELL = [
   '/',
   '/css/pusk.css',


### PR DESCRIPTION
## Summary
- Health endpoint now includes `demo` boolean field reflecting PUSK_DEMO env state
- Demo button and chat panel hidden on landing when demo mode is not active
- Org creation modal clears all input fields when reopened
- "Already have an account?" link hidden when user has active session

## Test plan
- [ ] Start without PUSK_DEMO — verify health returns demo:false, demo UI hidden
- [ ] Start with PUSK_DEMO=1 — verify health returns demo:true, demo UI visible
- [ ] Open org creation modal, fill fields, close, reopen — verify fields are empty
- [ ] Login, visit landing — verify login link is hidden