### PR TITLE
fix: push notifications in Firefox

### DIFF
--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -28,13 +28,17 @@ async function togglePush(){if((get('org')||'default')==='default'){toast(S.lang
     toast(S.lang==='ru'?'Push заблокирован в браузере. Разрешите в настройках сайта.':'Push blocked by browser. Allow in site settings.');
     return;
   }
-  // Check if already subscribed
+  // Request permission IMMEDIATELY on click (Firefox requires user gesture)
+  if(Notification.permission!=='granted'){
+    const perm=await Notification.requestPermission();
+    if(perm!=='granted'){$('s-push-btn').textContent=S.lang==='ru'?'Push: Выкл':'Push: Off';return}
+  }
+  // Permission granted — check subscription state
   if('serviceWorker' in navigator&&'PushManager' in window){
     try{
       const reg=await navigator.serviceWorker.ready;
       const sub=await reg.pushManager.getSubscription();
       if(sub){
-        // Currently subscribed -> unsubscribe
         const ep=sub.endpoint;
         await sub.unsubscribe();
         await api('DELETE','/api/push/subscribe',{endpoint:ep});
@@ -44,13 +48,10 @@ async function togglePush(){if((get('org')||'default')==='default'){toast(S.lang
       }
     }catch(e){console.warn('push unsub check error',e)}
   }
-  // Not subscribed -> subscribe
-  if(Notification.permission==='granted'){
-    registerPush();
-    toast(S.lang==='ru'?'Подписан на push уведомления':'Subscribed to push');
-    $('s-push-btn').textContent=S.lang==='ru'?'Push: Вкл ✓':'Push: On ✓';
-    {const hint=$('s-push-hint');if(hint)hint.remove()}
-  }else{Notification.requestPermission().then(p=>{if(p==='granted'){registerPush();$('s-push-btn').textContent=S.lang==='ru'?'Push: Вкл ✓':'Push: On ✓'}else{$('s-push-btn').textContent=S.lang==='ru'?'Push: Выкл':'Push: Off'}})}}
+  registerPush();
+  toast(S.lang==='ru'?'Подписан на push уведомления':'Subscribed to push');
+  $('s-push-btn').textContent=S.lang==='ru'?'Push: Вкл ✓':'Push: On ✓';
+  {const hint=$('s-push-hint');if(hint)hint.remove()}}
 
 function testPush(){if((get('org')||'default')==='default'){toast(S.lang==='ru'?'Push доступен только в организации. Создайте организацию в настройках.':'Push available only in organizations. Create one in settings.');return}api('POST','/api/push/test').then(r=>{if(r.ok){toast(S.lang==='ru'?'Push отправлен! Если не получили — проверьте: 1) Разрешения Chrome 2) Оптимизация батареи 3) Установите как приложение':'Push sent! Check: 1) Chrome permissions 2) Battery optimization 3) Install as app')}else{toast(r.error||(S.lang==='ru'?'Нет подписки на push. Включите Push в настройках.':'No push subscription. Enable Push first.'))}})}
 

--- a/web/static/js/ws.js
+++ b/web/static/js/ws.js
@@ -43,8 +43,7 @@ export async function registerPush(){
   if(!('serviceWorker' in navigator)||!('PushManager' in window)||!S.token)return;
   if((get('org')||'default')==='default')return;
   try{
-    const perm=await Notification.requestPermission();
-    if(perm!=='granted')return;
+    if(Notification.permission!=='granted')return;
     const reg=await navigator.serviceWorker.register('/sw.js');
     await navigator.serviceWorker.ready;
     const r=await fetch('/api/push/vapid');const{key}=await r.json();if(!key)return;

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -1,5 +1,5 @@
 // Pusk Service Worker — App Shell cache + Push notifications
-const CACHE = 'pusk-v86';
+const CACHE = 'pusk-v88';
 const SHELL = [
   '/',
   '/css/pusk.css',


### PR DESCRIPTION
## Summary
- Firefox requires `Notification.requestPermission()` inside a short-running user gesture handler
- `registerPush()` was calling `requestPermission()` on login (not a user gesture) — Firefox blocked it silently
- `togglePush()` was doing async `getSubscription()` before `requestPermission()` — broke the user gesture chain
- Now: `registerPush()` only subscribes if permission already granted, `togglePush()` requests permission first

## Test plan
- [ ] Firefox: click Push button in settings — permission dialog appears
- [ ] Firefox: grant permission — subscription persists after reload
- [ ] Chrome: push still works as before (regression)
- [ ] Login flow: no console errors about Notification permission