### PR TITLE
feat: DELETE /admin/org/{slug} + E2E cleanup

### DIFF
--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -37,6 +37,7 @@ func (a *AdminAPI) Route(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /admin/channel/{channelID}", a.renameChannel)
 	mux.HandleFunc("PUT /admin/bots/{botID}", a.renameBot)
 
+	mux.HandleFunc("DELETE /admin/org/{slug}", a.deleteOrg)
 	mux.HandleFunc("POST /admin/reset-password", a.resetPassword)
 	mux.HandleFunc("POST /admin/set-role", a.adminSetRole)
 
@@ -436,4 +437,34 @@ func (a *AdminAPI) adminSetRole(w http.ResponseWriter, r *http.Request) {
 	_ = s.SetUserRole(req.UserID, req.Role)
 	slog.Info("admin role set", "org", req.Org, "user_id", req.UserID, "role", req.Role)
 	_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}
+
+func (a *AdminAPI) deleteOrg(w http.ResponseWriter, r *http.Request) {
+	// Requires ADMIN_TOKEN (global admin only)
+	authHeader := r.Header.Get("Authorization")
+	if a.adminToken == "" || subtle.ConstantTimeCompare(
+		[]byte(strings.TrimPrefix(authHeader, "Bearer ")),
+		[]byte(a.adminToken),
+	) != 1 {
+		http.Error(w, `{"error":"admin token required"}`, http.StatusForbidden)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	if slug == "" {
+		jsonErr(w, "slug required", 400)
+		return
+	}
+	if slug == "default" {
+		jsonErr(w, "cannot delete default org", 400)
+		return
+	}
+
+	if err := a.orgs.DeleteOrg(slug); err != nil {
+		jsonErr(w, err.Error(), 404)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "deleted": slug})
 }

--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -300,6 +300,52 @@ func (m *Manager) CanCreateOrg() bool {
 }
 
 // Close closes all open stores
+
+// DeleteOrg removes an org: closes store, removes from registry, deletes data directory.
+// Protected: only "default" org cannot be deleted.
+func (m *Manager) DeleteOrg(slug string) error {
+	if slug == "default" {
+		return fmt.Errorf("cannot delete default org")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Close store if loaded
+	if s, ok := m.stores[slug]; ok {
+		s.Close()
+		delete(m.stores, slug)
+	}
+
+	// Remove from orgs list
+	filtered := make([]Org, 0, len(m.orgs))
+	found := false
+	for _, o := range m.orgs {
+		if o.Slug == slug {
+			found = true
+			continue
+		}
+		filtered = append(filtered, o)
+	}
+	if !found {
+		return fmt.Errorf("org not found: %s", slug)
+	}
+	m.orgs = filtered
+	_ = m.save()
+
+	// Remove tokens for this org
+	_, _ = m.tokDB.Exec("DELETE FROM tokens WHERE org = ?", slug)
+
+	// Remove data directory
+	orgDir := filepath.Join(m.dir, slug)
+	if err := os.RemoveAll(orgDir); err != nil {
+		slog.Warn("failed to remove org dir", "slug", slug, "err", err)
+	}
+
+	metrics.OrgsTotal.Set(float64(len(m.orgs)))
+	slog.Info("org deleted", "slug", slug)
+	return nil
+}
+
 func (m *Manager) Close() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -312,7 +312,7 @@ func (m *Manager) DeleteOrg(slug string) error {
 
 	// Close store if loaded
 	if s, ok := m.stores[slug]; ok {
-		s.Close()
+		_ = s.Close()
 		delete(m.stores, slug)
 	}
 

--- a/tests/e2e/pusk.spec.js
+++ b/tests/e2e/pusk.spec.js
@@ -13,6 +13,10 @@ async function api(method, path, body, token) {
   return { status: r.status, data: await r.json().catch(() => null) };
 }
 
+
+// Track created orgs for cleanup
+const createdSlugs = [];
+function trackSlug(slug) { createdSlugs.push(slug); return slug; }
 // ══════════════════════════════════════════
 // 1. LANDING & DEMO FLOW
 // ══════════════════════════════════════════
@@ -67,7 +71,7 @@ test.describe('Landing & Demo', () => {
 // 2. ORG REGISTRATION FLOW
 // ══════════════════════════════════════════
 test.describe('Org Registration', () => {
-  const slug = 'e2e-' + Date.now();
+  const slug = trackSlug('e2e-' + Date.now());
 
   test('create org via API', async () => {
     const r = await api('POST', '/api/org/register', {
@@ -95,7 +99,7 @@ test.describe('Org Registration', () => {
   });
 
   test('new org has system bot + #general', async () => {
-    const slug2 = 'e2ebot-' + Date.now();
+    const slug2 = trackSlug('e2ebot-' + Date.now());
     const reg = await api('POST', '/api/org/register', {
       slug: slug2, name: 'E2E Bot', username: 'admin', pin: 'test1234'
     });
@@ -113,7 +117,7 @@ test.describe('Org Registration', () => {
   });
 
   test('new org welcome message exists', async () => {
-    const slug3 = 'e2ewelc-' + Date.now();
+    const slug3 = trackSlug('e2ewelc-' + Date.now());
     const reg = await api('POST', '/api/org/register', {
       slug: slug3, name: 'E2E Welcome', username: 'admin', pin: 'test1234'
     });
@@ -163,7 +167,7 @@ test.describe('Auth & Security', () => {
 
   test('IDOR: same org, different users cannot read each others chats', async () => {
     // In same org: create 2 users, verify user2 cant read user1's chat
-    const slug = 'idor-' + Date.now();
+    const slug = trackSlug('idor-' + Date.now());
     const reg = await api('POST', '/api/org/register', {
       slug, name: 'IDOR', username: 'user1', pin: 'test1234'
     });
@@ -203,13 +207,13 @@ test.describe('SSRF Protection', () => {
 test.describe('Multi-tenant Isolation', () => {
   test('org1 data not visible from org2', async () => {
     const org1 = await api('POST', '/api/org/register', {
-      slug: 'iso1-' + Date.now(), name: 'ISO1', username: 'admin', pin: 'test1234'
+      slug: trackSlug('iso1-' + Date.now()), name: 'ISO1', username: 'admin', pin: 'test1234'
     });
     if (org1.status === 429) { test.skip(); return; }
     // wait for rate limit to reset slightly
     await new Promise(r => setTimeout(r, 1000));
     const org2 = await api('POST', '/api/org/register', {
-      slug: 'iso2-' + Date.now(), name: 'ISO2', username: 'admin', pin: 'test1234'
+      slug: trackSlug('iso2-' + Date.now()), name: 'ISO2', username: 'admin', pin: 'test1234'
     });
     if (org2.status === 429) { test.skip(); return; }
 
@@ -231,7 +235,7 @@ test.describe('Multi-tenant Isolation', () => {
     expect(defaultBots.data.length).toBe(2); // DemoBot + MonitorBot
 
     const newOrg = await api('POST', '/api/org/register', {
-      slug: 'clnorg-' + Date.now(), name: 'Clean', username: 'admin', pin: 'test1234'
+      slug: trackSlug('clnorg-' + Date.now()), name: 'Clean', username: 'admin', pin: 'test1234'
     });
     if (newOrg.status === 429) { test.skip(); return; }
     const newBots = await api('GET', '/api/bots', null, newOrg.data.token);
@@ -245,7 +249,7 @@ test.describe('Multi-tenant Isolation', () => {
 test.describe('Bot API', () => {
   test('sendMessage via Bot API', async () => {
     // Use isolated org so E2E tests don't pollute default demo data
-    const slug = 'e2e-botapi-' + Date.now();
+    const slug = trackSlug('e2e-botapi-' + Date.now());
     const reg = await api('POST', '/api/org/register', { slug, name: slug, username: 'admin', pin: 'admin123' });
     const token = reg.data.token;
     const bots = await api('GET', '/api/bots', null, token);
@@ -367,7 +371,7 @@ test.describe('Webhook Endpoints', () => {
 // ══════════════════════════════════════════
 test.describe('Rate Limiting', () => {
   test('rate limiting after 20 auth attempts', async () => {
-    const user = 'ratelimit-' + Date.now();
+    const user = trackSlug('ratelimit-' + Date.now());
     for (let i = 0; i < 20; i++) {
       await api('POST', '/api/auth', { username: user, pin: 'wrong123' });
     }
@@ -375,3 +379,22 @@ test.describe('Rate Limiting', () => {
     expect(r.status).toBe(429);
   });
 });
+
+// ══════════════════════════════════════════
+// CLEANUP — delete test orgs after all tests
+// ══════════════════════════════════════════
+test.afterAll(async () => {
+  if (createdSlugs.length === 0) return;
+  const adminToken = process.env.PUSK_ADMIN_TOKEN;
+  if (!adminToken) {
+    console.log(`[cleanup] PUSK_ADMIN_TOKEN not set, skipping cleanup of ${createdSlugs.length} test orgs`);
+    return;
+  }
+  let deleted = 0;
+  for (const slug of createdSlugs) {
+    const r = await api('DELETE', `/admin/org/${slug}`, null, `Bearer ${adminToken}`);
+    if (r.status === 200) deleted++;
+  }
+  console.log(`[cleanup] deleted ${deleted}/${createdSlugs.length} test orgs`);
+});
+


### PR DESCRIPTION
## Summary
- Add `DELETE /admin/org/{slug}` endpoint (requires `ADMIN_TOKEN`)
- E2E tests now track created org slugs and delete them in `afterAll`
- Prevents test org accumulation on production

## Test plan
- [ ] Run E2E with `PUSK_ADMIN_TOKEN` set — verify cleanup happens
- [ ] Verify `default` org cannot be deleted
- [ ] Verify non-admin requests are rejected