### PR TITLE
fix(docs): Zabbix webhook script missing JSON.parse

### DIFF
--- a/docs/use-cases.en.md
+++ b/docs/use-cases.en.md
@@ -211,6 +211,7 @@ This is the "delivery method" — how Zabbix will send alerts to Pusk.
 7. In the **Script** field paste this code (copy it entirely):
 
    ```javascript
+   var params = JSON.parse(value);
    var req = new HttpRequest();
    req.addHeader('Content-Type: application/json');
    var data = JSON.stringify({

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -211,6 +211,7 @@ docker compose ps
 7. В поле **Script** вставьте этот код (скопируйте целиком):
 
    ```javascript
+   var params = JSON.parse(value);
    var req = new HttpRequest();
    req.addHeader('Content-Type: application/json');
    var data = JSON.stringify({


### PR DESCRIPTION
## Summary

- Zabbix webhook scripts receive parameters as a JSON string via the `value` variable
- The script must call `var params = JSON.parse(value)` before accessing `params.*` fields
- Without this line the script fails with `ReferenceError: identifier 'params' undefined`
- All 32 built-in Zabbix webhook templates use this pattern

Fixes #89