### PR TITLE
feat: bot management — rename, delete, UI controls

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -278,6 +278,7 @@ All endpoints require `Authorization: Bearer <PUSK_ADMIN_TOKEN>` or a JWT with a
 | `DELETE` | `/admin/channel/{id}` | Delete channel (except #general) |
 | `PUT` | `/admin/channel/{id}` | Rename channel (`name`) |
 | `PUT` | `/admin/bots/{id}` | Rename bot (`name`) |
+| `DELETE` | `/admin/bots/{id}` | Delete bot (if no channels assigned) |
 | `POST` | `/admin/reset-password` | Reset password (`org`, `username`, `new_pin`). ADMIN_TOKEN only |
 | `POST` | `/admin/set-role` | Set role (`org`, `user_id`, `role`: admin/member). ADMIN_TOKEN only |
 | `GET` | `/api/org/info` | Organization limit info |

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ server {
 | `DELETE` | `/admin/channel/{id}` | Удалить канал (кроме #general) |
 | `PUT` | `/admin/channel/{id}` | Переименовать канал (`name`) |
 | `PUT` | `/admin/bots/{id}` | Переименовать бота (`name`) |
+| `DELETE` | `/admin/bots/{id}` | Удалить бота (если нет каналов) |
 | `POST` | `/admin/reset-password` | Сбросить пароль (`org`, `username`, `new_pin`). Только ADMIN_TOKEN |
 | `POST` | `/admin/set-role` | Назначить роль (`org`, `user_id`, `role`: admin/member). Только ADMIN_TOKEN |
 | `GET` | `/api/org/info` | Информация о лимитах организаций |

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -37,6 +37,7 @@ func (a *AdminAPI) Route(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /admin/channel/{channelID}", a.renameChannel)
 	mux.HandleFunc("PUT /admin/channel/{channelID}/bot", a.updateChannelBot)
 	mux.HandleFunc("PUT /admin/bots/{botID}", a.renameBot)
+	mux.HandleFunc("DELETE /admin/bots/{botID}", a.deleteBot)
 
 	mux.HandleFunc("DELETE /admin/org/{slug}", a.deleteOrg)
 	mux.HandleFunc("POST /admin/reset-password", a.resetPassword)
@@ -510,4 +511,27 @@ func (a *AdminAPI) deleteOrg(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "deleted": slug})
+}
+
+func (a *AdminAPI) deleteBot(w http.ResponseWriter, r *http.Request) {
+	s, ok := a.getOrgStore(r)
+	if !ok {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	if !a.requireAdmin(r, s) {
+		http.Error(w, `{"error":"admin only"}`, http.StatusForbidden)
+		return
+	}
+	botID, _ := strconv.ParseInt(r.PathValue("botID"), 10, 64)
+	bot, _ := s.BotByID(botID)
+	if err := s.DeleteBot(botID); err != nil {
+		jsonErr(w, err.Error(), 400)
+		return
+	}
+	if bot != nil {
+		a.orgs.UnregisterToken(bot.Token)
+	}
+	slog.Info("bot deleted", "bot_id", botID)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
 }

--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -79,6 +79,11 @@ func (m *Manager) RegisterToken(token, orgSlug string) {
 	_, _ = m.tokDB.Exec("INSERT OR REPLACE INTO tokens (token, org) VALUES (?, ?)", token, orgSlug)
 }
 
+// UnregisterToken removes a bot token from the global registry.
+func (m *Manager) UnregisterToken(token string) {
+	_, _ = m.tokDB.Exec("DELETE FROM tokens WHERE token=?", token)
+}
+
 func (m *Manager) registerTokenLocked(token, orgSlug string) {
 	_, _ = m.tokDB.Exec("INSERT OR REPLACE INTO tokens (token, org) VALUES (?, ?)", token, orgSlug)
 }

--- a/internal/store/bots.go
+++ b/internal/store/bots.go
@@ -2,6 +2,8 @@
 // Licensed under the Business Source License 1.1. See LICENSE file for details.
 package store
 
+import "fmt"
+
 // Bot represents a registered bot.
 type Bot struct {
 	ID         int64  `json:"id"`
@@ -66,4 +68,36 @@ func (s *Store) BotByID(id int64) (*Bot, error) {
 func (s *Store) RenameBot(botID int64, name string) error {
 	_, err := s.db.Exec("UPDATE bots SET name=? WHERE id=?", name, botID)
 	return err
+}
+
+// DeleteBot removes a bot if it has no channels assigned.
+func (s *Store) DeleteBot(botID int64) error {
+	var count int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM channels WHERE bot_id=?", botID).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("bot has %d channel(s) — reassign them first", count)
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec("DELETE FROM callback_queue WHERE bot_id=?", botID); err != nil {
+		return fmt.Errorf("delete callbacks: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM files WHERE bot_id=?", botID); err != nil {
+		return fmt.Errorf("delete files: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM messages WHERE chat_id IN (SELECT id FROM chats WHERE bot_id=?)", botID); err != nil {
+		return fmt.Errorf("delete messages: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM chats WHERE bot_id=?", botID); err != nil {
+		return fmt.Errorf("delete chats: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM bots WHERE id=?", botID); err != nil {
+		return fmt.Errorf("delete bot: %w", err)
+	}
+	return tx.Commit()
 }

--- a/web/static/css/pusk.css
+++ b/web/static/css/pusk.css
@@ -215,6 +215,9 @@ header h2{font-size:14px;font-weight:600;flex:1}
 
 /* views.js: bot token */
 .bot-token{font-size:11px;color:var(--text2);margin-top:2px;word-break:break-all;cursor:pointer}
+.bot-del{background:none;border:none;color:var(--text2);font-size:14px;cursor:pointer;padding:2px 6px;margin-left:8px;border-radius:4px;opacity:0.5}
+.bot-del:hover{color:var(--danger,#e74c3c);opacity:1}
+.bot-name{cursor:pointer}.bot-name:hover{text-decoration:underline}
 
 /* actions.js: autocomplete items */
 .ac-item{padding:8px 12px;cursor:pointer;font-size:14px;color:var(--accent)}

--- a/web/static/js/views.js
+++ b/web/static/js/views.js
@@ -213,6 +213,8 @@ export async function showList(){try{S.curChat=null;S.curChan=null;S.mentionUser
 
       if(isAdmin){const tokDiv=document.createElement('div');tokDiv.className='bot-token';tokDiv.dataset.token=b.token;tokDiv.textContent=t('show_tok');info.appendChild(tokDiv)}
 
+      if(isAdmin){const delBtn=document.createElement('button');delBtn.className='bot-del';delBtn.dataset.botId=b.id;delBtn.dataset.botName=b.name;delBtn.textContent='✕';delBtn.title=S.lang==='ru'?'Удалить бота':'Delete bot';info.appendChild(delBtn)}
+
       row.appendChild(info);
       el.appendChild(row);
     }
@@ -232,6 +234,9 @@ $('main-list').addEventListener('click',e=>{
   // Channel row
   const chRow=e.target.closest('.ch-row');
   if(chRow){openChan(+chRow.dataset.chanId,chRow.dataset.chanName);return}
+  // Bot delete button
+  const botDel=e.target.closest('.bot-del');
+  if(botDel){e.stopPropagation();const bid=+botDel.dataset.botId;const bname=botDel.dataset.botName;if(!confirm((S.lang==='ru'?'Удалить бота "'+bname+'"?':'Delete bot "'+bname+'"?')))return;api('DELETE','/admin/bots/'+bid).then(r=>{if(r&&r.ok){toast(S.lang==='ru'?'Бот удалён':'Bot deleted');showList()}else{toast(r&&r.error||'Error')}});return}
   // Bot row
   const botRow=e.target.closest('.bot-row');
   if(botRow){openChat(+botRow.dataset.botId,botRow.dataset.botName);return}
@@ -262,4 +267,9 @@ export function updateAvatarDots(users){if(!users)return;const map={};users.forE
 $('hdr-back').onclick=showList;
 async function renameCurrentChan(){if(!S.curChan||get('role')!=='admin')return;const ch=S.channels.find(c=>c.id===S.curChan);if(!ch||ch.name==='general')return;const name=prompt(S.lang==='ru'?'Новое имя канала:':'New channel name:',ch.name);if(!name||name===ch.name)return;const r=await api('PUT','/admin/channel/'+S.curChan,{name});if(r&&r.ok){ch.name=name;$('hdr-title').textContent='# '+name;toast(S.lang==='ru'?'Переименовано':'Renamed')}else{toast(r.error||'Error')}}
 $('hdr-title').addEventListener('dblclick',renameCurrentChan);
+$('main-list').addEventListener('dblclick',e=>{const botName=e.target.closest('.bot-name');if(!botName||get('role')!=='admin')return;const row=botName.closest('.bot-row');if(!row)return;const bid=+row.dataset.botId;const oldName=row.dataset.botName;const name=prompt(S.lang==='ru'?'Новое имя бота:':'New bot name:',oldName);if(!name||name===oldName)return;api('PUT','/admin/bots/'+bid,{name}).then(r=>{if(r&&r.ok){toast(S.lang==='ru'?'Переименовано':'Renamed');showList()}else{toast(r&&r.error||'Error')}})});
+let _botLong=null;
+$('main-list').addEventListener('touchstart',e=>{const bn=e.target.closest('.bot-name');if(!bn||get('role')!=='admin')return;const row=bn.closest('.bot-row');if(!row)return;_botLong=setTimeout(()=>{const bid=+row.dataset.botId;const oldName=row.dataset.botName;const name=prompt(S.lang==='ru'?'\u041d\u043e\u0432\u043e\u0435 \u0438\u043c\u044f \u0431\u043e\u0442\u0430:':'New bot name:',oldName);if(!name||name===oldName)return;api('PUT','/admin/bots/'+bid,{name}).then(r=>{if(r&&r.ok){toast(S.lang==='ru'?'\u041f\u0435\u0440\u0435\u0438\u043c\u0435\u043d\u043e\u0432\u0430\u043d\u043e':'Renamed');showList()}else{toast(r&&r.error||'Error')}})},800)},{passive:true});
+$('main-list').addEventListener('touchend',e=>{if(_botLong){clearTimeout(_botLong);_botLong=null}},{passive:true});
+$('main-list').addEventListener('touchmove',e=>{if(_botLong){clearTimeout(_botLong);_botLong=null}},{passive:true});
 let _hdrLong=null;$('hdr-title').addEventListener('touchstart',()=>{_hdrLong=setTimeout(renameCurrentChan,800)},{passive:true});$('hdr-title').addEventListener('touchend',()=>{if(_hdrLong){clearTimeout(_hdrLong);_hdrLong=null}},{passive:true});$('hdr-title').addEventListener('touchmove',()=>{if(_hdrLong){clearTimeout(_hdrLong);_hdrLong=null}},{passive:true});

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -1,5 +1,5 @@
 // Pusk Service Worker — App Shell cache + Push notifications
-const CACHE = 'pusk-v96';
+const CACHE = 'pusk-v98';
 const SHELL = [
   '/',
   '/css/pusk.css',


### PR DESCRIPTION
## Summary
- Add DELETE /admin/bots/{botID} endpoint with cascade cleanup (chats, messages, files, callbacks)
- Add bot rename via double-click on bot name in channel list
- Add delete button (x) with confirmation dialog on bot rows
- Prevent deletion of bots that have channels assigned — must reassign first
- CSS: bot-del hover state, bot-name underline hint for dblclick
- Docs: add DELETE endpoint to API reference in README

## Test plan
- [ ] Double-click bot name in list → rename prompt → verify name updates
- [ ] Click x on bot row → confirm → verify bot deleted (only if no channels)
- [ ] Try deleting bot with channels → verify error message
- [ ] Mobile: long-press bot name → rename prompt