### PR TITLE
ci: add JS syntax check and run all E2E specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
         run: go install mvdan.cc/gofumpt@latest
       - name: gofumpt
         run: test -z "$(gofumpt -l .)"
+      - name: JS syntax check
+        run: |
+          for f in web/static/js/*.js; do
+            node --check "$f" || { echo "SYNTAX ERROR in $f"; exit 1; }
+          done
       - name: JS function integrity
         run: |
           for fn in addMsg sendMsg showList openChat openChan connectWS onCb onDel toggleSub showApp logout auth setLang beep scrollDown; do
@@ -198,7 +203,7 @@ jobs:
         env:
           PUSK_URL: http://localhost:9999
           BASE_URL: http://localhost:9999
-        run: npx playwright test pusk.spec.js
+        run: npx playwright test
 
       - name: Stop Pusk
         if: always()

--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -161,6 +161,9 @@ func main() {
 
 	// Admin API (admin endpoints + org registration)
 	adminAPI := api.NewAdminAPI(orgs, db, jwtSvc, adminToken)
+	if os.Getenv("PUSK_DEMO") == "1" {
+		adminAPI.DemoMode = true
+	}
 	adminAPI.Route(mux)
 
 	// Invite redirect → PWA with invite param

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -22,6 +22,7 @@ type AdminAPI struct {
 	store      *store.Store
 	jwt        *auth.JWTService
 	adminToken string
+	DemoMode   bool
 }
 
 // NewAdminAPI creates a new AdminAPI.
@@ -43,7 +44,11 @@ func (a *AdminAPI) Route(mux *http.ServeMux) {
 	mux.HandleFunc("POST /admin/reset-password", a.resetPassword)
 	mux.HandleFunc("POST /admin/set-role", a.adminSetRole)
 
-	orgRL := NewRateLimiter(10, time.Minute)
+	orgRate := 10
+	if a.DemoMode {
+		orgRate = 600
+	}
+	orgRL := NewRateLimiter(orgRate, time.Minute)
 	mux.HandleFunc("GET /api/org/info", a.orgInfo)
 	mux.HandleFunc("POST /api/org/register", RateLimit(orgRL, a.registerOrg))
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -69,10 +69,14 @@ func (a *ClientAPI) db(r *http.Request) *store.Store {
 }
 
 func (a *ClientAPI) Route(mux *http.ServeMux) {
-	authRL := NewRateLimiter(10, time.Minute) // 10 auth/min per IP
-	regRL := NewRateLimiter(10, time.Minute)
-	sendRL := NewRateLimiter(30, time.Minute)   // 30 msgs/min per IP
-	uploadRL := NewRateLimiter(10, time.Minute) // 10 uploads/min per IP
+	authRate, regRate, sendRate, uploadRate := 10, 10, 30, 10
+	if a.DemoMode {
+		authRate, regRate, sendRate, uploadRate = 600, 600, 600, 600
+	}
+	authRL := NewRateLimiter(authRate, time.Minute)
+	regRL := NewRateLimiter(regRate, time.Minute)
+	sendRL := NewRateLimiter(sendRate, time.Minute)
+	uploadRL := NewRateLimiter(uploadRate, time.Minute)
 
 	// Public routes (no auth required)
 	mux.HandleFunc("POST /api/auth", RateLimit(authRL, limitBody(a.auth)))


### PR DESCRIPTION
## Summary
- Add JS syntax check (`node --check`) to CI
- Run all E2E spec files, not just `pusk.spec.js`
- Relax rate limits in demo mode so E2E tests don't hit 429

Closes #102

## Test plan
- [ ] CI passes
- [ ] All E2E specs execute