### PR TITLE
ci: move secret scan from action to CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,6 @@ jobs:
       - name: Coherence check
         run: bash scripts/coherence-check.sh
 
-  gitleaks:
-    name: Gitleaks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   security:
     name: Security
     runs-on: ubuntu-latest
@@ -86,6 +75,12 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.x'
+
+      - name: Gitleaks — secret detection
+        run: |
+          curl -sL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
+            | tar xz -C /usr/local/bin gitleaks
+          gitleaks detect --source . --config .gitleaks.toml --exit-code 1
 
       - name: Secret scan — private IPs and internal domains
         run: |


### PR DESCRIPTION
Replace gitleaks GitHub Action with CLI binary.
The action requires a paid license for organization repos.
CLI produces the same results without license dependency.