### PR TITLE
sec: annotate gosec false positives G703, G710

### DIFF
--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -174,7 +174,7 @@ func main() {
 		if org != "" {
 			target += "&org=" + org
 		}
-		http.Redirect(w, r, target, http.StatusFound)
+		http.Redirect(w, r, target, http.StatusFound) // #nosec G710 -- target is a relative path built from query params
 	})
 
 	mux.HandleFunc("GET /metrics", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -568,7 +568,7 @@ func (h *Handler) serveFile(w http.ResponseWriter, r *http.Request) {
 	s := h.storeForJWT(tokenStr)
 	f, err := s.GetFile(fileID)
 	if err == nil {
-		http.ServeFile(w, r, f.Path)
+		http.ServeFile(w, r, f.Path) // #nosec G703 -- f.Path from trusted store lookup by opaque fileID
 		return
 	}
 
@@ -579,7 +579,7 @@ func (h *Handler) serveFile(w http.ResponseWriter, r *http.Request) {
 		if h.store != nil {
 			if _, err := h.store.ValidateFileToken(tokenStr); err == nil {
 				if f, err := h.store.GetFile(fileID); err == nil {
-					http.ServeFile(w, r, f.Path)
+					http.ServeFile(w, r, f.Path) // #nosec G703 -- f.Path from trusted store lookup by opaque fileID
 					return
 				}
 			}
@@ -590,7 +590,7 @@ func (h *Handler) serveFile(w http.ResponseWriter, r *http.Request) {
 				if os, err := h.orgs.Get(o.Slug); err == nil {
 					if _, err := os.ValidateFileToken(tokenStr); err == nil {
 						if f, err := os.GetFile(fileID); err == nil {
-							http.ServeFile(w, r, f.Path)
+							http.ServeFile(w, r, f.Path) // #nosec G703 -- f.Path from trusted store lookup by opaque fileID
 							return
 						}
 					}


### PR DESCRIPTION
## Summary
- Annotate 3x `http.ServeFile` calls with `#nosec G703` — path comes from trusted store lookup by opaque fileID, not user input
- Annotate 1x `http.Redirect` call with `#nosec G710` — target is always a relative path (`/?invite=...`) built programmatically

## Context
Gosec `dev` version introduced G703/G710 rules that flag these as false positives. This unblocks dependabot PRs #110 and #111.

## Test plan
- [ ] Security CI job passes (gosec reports 0 new issues)
- [ ] Existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)