### PR TITLE
feat: channel info endpoint and WS rename broadcast

### DIFF
--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -160,7 +160,7 @@ func main() {
 	clientAPI.Route(mux)
 
 	// Admin API (admin endpoints + org registration)
-	adminAPI := api.NewAdminAPI(orgs, db, jwtSvc, adminToken)
+	adminAPI := api.NewAdminAPI(orgs, db, hub, jwtSvc, adminToken)
 	if os.Getenv("PUSK_DEMO") == "1" {
 		adminAPI.DemoMode = true
 	}

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -14,20 +14,22 @@ import (
 	"github.com/pusk-platform/pusk/internal/auth"
 	"github.com/pusk-platform/pusk/internal/org"
 	"github.com/pusk-platform/pusk/internal/store"
+	"github.com/pusk-platform/pusk/internal/ws"
 )
 
 // AdminAPI handles admin and org-registration endpoints.
 type AdminAPI struct {
 	orgs       *org.Manager
 	store      *store.Store
+	hub        *ws.Hub
 	jwt        *auth.JWTService
 	adminToken string
 	DemoMode   bool
 }
 
 // NewAdminAPI creates a new AdminAPI.
-func NewAdminAPI(orgs *org.Manager, s *store.Store, jwt *auth.JWTService, adminToken string) *AdminAPI {
-	return &AdminAPI{orgs: orgs, store: s, jwt: jwt, adminToken: adminToken}
+func NewAdminAPI(orgs *org.Manager, s *store.Store, hub *ws.Hub, jwt *auth.JWTService, adminToken string) *AdminAPI {
+	return &AdminAPI{orgs: orgs, store: s, hub: hub, jwt: jwt, adminToken: adminToken}
 }
 
 // Route registers admin routes on the given mux.
@@ -255,6 +257,23 @@ func (a *AdminAPI) renameChannel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	slog.Info("channel renamed", "channel_id", channelID, "new_name", req.Name)
+
+	// Broadcast rename to connected clients
+	if a.hub != nil {
+		orgID := "default"
+		authHeader := r.Header.Get("Authorization")
+		if a.jwt != nil && authHeader != "" {
+			if claims, err := a.jwt.Validate(authHeader); err == nil {
+				orgID = claims.OrgID
+			}
+		}
+		payload, _ := json.Marshal(map[string]interface{}{
+			"channel_id": channelID,
+			"name":       req.Name,
+		})
+		a.hub.SendToOrg(orgID, ws.Event{Type: "channel_rename", ChatID: channelID, Payload: payload}, "")
+	}
+
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
 }
 

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -47,7 +47,7 @@ func newAdminEnv(t *testing.T) *adminEnv {
 	}
 
 	adminToken := "super-secret-admin-token"
-	api := NewAdminAPI(mgr, s, jwtSvc, adminToken)
+	api := NewAdminAPI(mgr, s, nil, jwtSvc, adminToken)
 
 	mux := http.NewServeMux()
 	api.Route(mux)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -723,3 +723,76 @@ func TestListChats_Unauthed(t *testing.T) {
 		t.Fatalf("unauth chats: got %d, want 401", rec.Code)
 	}
 }
+
+// ── Channel Info ──
+
+func TestChannelInfo(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Register user
+	regRec := env.request("POST", "/api/register", map[string]string{
+		"username": "infouser", "pin": "pass123456",
+	})
+	token := decodeJSON(t, regRec)["token"].(string)
+
+	// Create channel via store
+	s, _ := env.orgs.Get("default")
+	bot, _ := s.CreateBot("tok-info-api", "InfoBot")
+	ch, _ := s.CreateChannel(bot.ID, "info-chan", "channel for info test")
+
+	// Subscribe user
+	u, _ := s.AuthUser("infouser", "pass123456")
+	_ = s.Subscribe(ch.ID, u.ID)
+
+	// GET /api/channels/{id}/info
+	rec := env.authedRequest("GET", fmt.Sprintf("/api/channels/%d/info", ch.ID), nil, token)
+	if rec.Code != 200 {
+		t.Fatalf("channel info: got %d, body: %s", rec.Code, rec.Body.String())
+	}
+
+	data := decodeJSON(t, rec)
+	if data["name"] != "info-chan" {
+		t.Errorf("expected name info-chan, got %v", data["name"])
+	}
+	if data["description"] != "channel for info test" {
+		t.Errorf("expected description, got %v", data["description"])
+	}
+	if data["bot_name"] != "InfoBot" {
+		t.Errorf("expected bot_name InfoBot, got %v", data["bot_name"])
+	}
+	if data["created_at"] == nil || data["created_at"] == "" {
+		t.Error("expected non-empty created_at")
+	}
+	subs, ok := data["subscribers"].([]interface{})
+	if !ok {
+		t.Fatalf("expected subscribers array, got %T", data["subscribers"])
+	}
+	if len(subs) != 1 {
+		t.Errorf("expected 1 subscriber, got %d", len(subs))
+	}
+	subCount := int(data["subscriber_count"].(float64))
+	if subCount != 1 {
+		t.Errorf("expected subscriber_count 1, got %d", subCount)
+	}
+}
+
+func TestChannelInfo_NotFound(t *testing.T) {
+	env := newTestEnv(t)
+	regRec := env.request("POST", "/api/register", map[string]string{
+		"username": "infonf", "pin": "pass123456",
+	})
+	token := decodeJSON(t, regRec)["token"].(string)
+
+	rec := env.authedRequest("GET", "/api/channels/99999/info", nil, token)
+	if rec.Code != 404 {
+		t.Fatalf("channel info not found: got %d, want 404", rec.Code)
+	}
+}
+
+func TestChannelInfo_Unauthed(t *testing.T) {
+	env := newTestEnv(t)
+	rec := env.request("GET", "/api/channels/1/info", nil)
+	if rec.Code != 401 {
+		t.Fatalf("channel info unauthed: got %d, want 401", rec.Code)
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -101,6 +101,7 @@ func (a *ClientAPI) Route(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/channels/{channelID}/subscribe", a.AuthRequired(a.subscribe))
 	mux.HandleFunc("POST /api/channels/{channelID}/unsubscribe", a.AuthRequired(a.unsubscribe))
 	mux.HandleFunc("GET /api/channels/{channelID}/messages", a.AuthRequired(a.channelMessages))
+	mux.HandleFunc("GET /api/channels/{channelID}/info", a.AuthRequired(a.channelInfo))
 	mux.HandleFunc("GET /api/channels/{channelID}/readers", a.AuthRequired(a.channelReaders))
 	mux.HandleFunc("POST /api/channels/{channelID}/send", a.AuthRequired(RateLimit(sendRL, limitBody(a.sendToChannel))))
 	mux.HandleFunc("POST /api/channels/{channelID}/ack", a.AuthRequired(limitBody(a.ackChannelMessage)))

--- a/internal/api/client_channels.go
+++ b/internal/api/client_channels.go
@@ -32,6 +32,41 @@ func (a *ClientAPI) broadcastChannel(_ *store.Store, channelID int64, orgID, evT
 	a.hub.SendToOrg(orgID, ws.Event{Type: evType, ChatID: channelID, Payload: payload}, excludeKey)
 }
 
+func (a *ClientAPI) channelInfo(w http.ResponseWriter, r *http.Request) {
+	channelID, _ := strconv.ParseInt(r.PathValue("channelID"), 10, 64)
+	s := a.db(r)
+
+	ch, err := s.ChannelByID(channelID)
+	if err != nil {
+		jsonErr(w, "channel not found", 404)
+		return
+	}
+
+	botName := ""
+	if bot, berr := s.BotByID(ch.BotID); berr == nil && bot != nil {
+		botName = bot.Name
+	}
+
+	subs, _ := s.ChannelSubscribersJoin(channelID)
+	if subs == nil {
+		subs = []store.ChannelSubscriber{}
+	}
+
+	pinned := s.GetPinnedMessage(channelID)
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":                ch.ID,
+		"name":              ch.Name,
+		"description":       ch.Description,
+		"bot_id":            ch.BotID,
+		"bot_name":          botName,
+		"created_at":        ch.CreatedAt,
+		"subscribers":       subs,
+		"subscriber_count":  len(subs),
+		"pinned_message_id": pinned,
+	})
+}
+
 func (a *ClientAPI) channelReaders(w http.ResponseWriter, r *http.Request) {
 	channelID, _ := strconv.ParseInt(r.PathValue("channelID"), 10, 64)
 	s := a.db(r)

--- a/internal/store/channels.go
+++ b/internal/store/channels.go
@@ -13,6 +13,7 @@ type Channel struct {
 	BotID       int64  `json:"bot_id"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
 }
 
 // ChannelMessage represents a message in a channel.
@@ -42,20 +43,20 @@ func (s *Store) CreateChannel(botID int64, name, description string) (*Channel, 
 
 func (s *Store) ChannelByName(botID int64, name string) (*Channel, error) {
 	ch := &Channel{}
-	err := s.db.QueryRow("SELECT id, bot_id, name, COALESCE(description,'') FROM channels WHERE bot_id=? AND name=?",
-		botID, name).Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description)
+	err := s.db.QueryRow("SELECT id, bot_id, name, COALESCE(description,''), COALESCE(created_at,'') FROM channels WHERE bot_id=? AND name=?",
+		botID, name).Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description, &ch.CreatedAt)
 	return ch, err
 }
 
 func (s *Store) ChannelByID(id int64) (*Channel, error) {
 	ch := &Channel{}
-	err := s.db.QueryRow("SELECT id, bot_id, name, COALESCE(description,'') FROM channels WHERE id=?",
-		id).Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description)
+	err := s.db.QueryRow("SELECT id, bot_id, name, COALESCE(description,''), COALESCE(created_at,'') FROM channels WHERE id=?",
+		id).Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description, &ch.CreatedAt)
 	return ch, err
 }
 
 func (s *Store) ListChannels() ([]Channel, error) {
-	rows, err := s.db.Query("SELECT id, bot_id, name, COALESCE(description,'') FROM channels ORDER BY CASE WHEN name='general' THEN 0 ELSE 1 END, name")
+	rows, err := s.db.Query("SELECT id, bot_id, name, COALESCE(description,''), COALESCE(created_at,'') FROM channels ORDER BY CASE WHEN name='general' THEN 0 ELSE 1 END, name")
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,7 @@ func (s *Store) ListChannels() ([]Channel, error) {
 	var chs []Channel
 	for rows.Next() {
 		var ch Channel
-		if err := rows.Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description); err != nil {
+		if err := rows.Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description, &ch.CreatedAt); err != nil {
 			continue
 		}
 		chs = append(chs, ch)
@@ -101,7 +102,7 @@ func (s *Store) ChannelSubscribers(channelID int64) ([]int64, error) {
 }
 
 func (s *Store) UserSubscriptions(userID int64) ([]Channel, error) {
-	rows, err := s.db.Query(`SELECT c.id, c.bot_id, c.name, COALESCE(c.description,'')
+	rows, err := s.db.Query(`SELECT c.id, c.bot_id, c.name, COALESCE(c.description,''), COALESCE(c.created_at,'')
 		FROM channels c JOIN channel_subscribers cs ON c.id = cs.channel_id
 		WHERE cs.user_id = ?`, userID)
 	if err != nil {
@@ -111,7 +112,7 @@ func (s *Store) UserSubscriptions(userID int64) ([]Channel, error) {
 	var chs []Channel
 	for rows.Next() {
 		var ch Channel
-		if err := rows.Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description); err != nil {
+		if err := rows.Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description, &ch.CreatedAt); err != nil {
 			continue
 		}
 		chs = append(chs, ch)
@@ -283,6 +284,35 @@ func (s *Store) ListChannelsForUser(userID int64) ([]ChannelInfo, error) {
 		result = append(result, ci)
 	}
 	return result, nil
+}
+
+// ChannelSubscriber represents a user subscribed to a channel (with username from JOIN).
+type ChannelSubscriber struct {
+	UserID   int64  `json:"user_id"`
+	Username string `json:"username"`
+}
+
+// ChannelSubscribersJoin returns subscribers with usernames in a single JOIN query.
+func (s *Store) ChannelSubscribersJoin(channelID int64) ([]ChannelSubscriber, error) {
+	rows, err := s.db.Query(`
+		SELECT cs.user_id, u.username
+		FROM channel_subscribers cs
+		JOIN users u ON cs.user_id = u.id
+		WHERE cs.channel_id = ?
+		ORDER BY u.username`, channelID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var subs []ChannelSubscriber
+	for rows.Next() {
+		var sub ChannelSubscriber
+		if err := rows.Scan(&sub.UserID, &sub.Username); err != nil {
+			continue
+		}
+		subs = append(subs, sub)
+	}
+	return subs, nil
 }
 
 // ChannelReader represents a user who has read messages in a channel.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -996,3 +996,64 @@ func TestDeleteChannelMessage_ClearsPin(t *testing.T) {
 		t.Errorf("pin should be cleared after message delete, got %d", pid)
 	}
 }
+
+// ── ChannelSubscribersJoin ──
+
+func TestChannelSubscribersJoin(t *testing.T) {
+	s := newTestStore(t)
+	bot, _ := s.CreateBot("csjb", "CSJBot")
+	u1, _ := s.CreateUser("alice", "p", "")
+	u2, _ := s.CreateUser("bob", "p", "")
+	ch, _ := s.CreateChannel(bot.ID, "subjoin", "")
+
+	_ = s.Subscribe(ch.ID, u1.ID)
+	_ = s.Subscribe(ch.ID, u2.ID)
+
+	subs, err := s.ChannelSubscribersJoin(ch.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subs) != 2 {
+		t.Fatalf("expected 2 subscribers, got %d", len(subs))
+	}
+	// Sorted by username: alice < bob
+	if subs[0].Username != "alice" {
+		t.Errorf("expected alice first, got %s", subs[0].Username)
+	}
+	if subs[1].Username != "bob" {
+		t.Errorf("expected bob second, got %s", subs[1].Username)
+	}
+}
+
+func TestChannelSubscribersJoin_Empty(t *testing.T) {
+	s := newTestStore(t)
+	bot, _ := s.CreateBot("csje", "CSJEBot")
+	ch, _ := s.CreateChannel(bot.ID, "emptysub", "")
+
+	subs, err := s.ChannelSubscribersJoin(ch.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subs) != 0 {
+		t.Fatalf("expected 0 subscribers, got %d", len(subs))
+	}
+}
+
+// ── Channel CreatedAt ──
+
+func TestChannelByID_CreatedAt(t *testing.T) {
+	s := newTestStore(t)
+	bot, _ := s.CreateBot("ccab", "CCABot")
+	created, _ := s.CreateChannel(bot.ID, "tschan", "test channel")
+
+	ch, err := s.ChannelByID(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ch.CreatedAt == "" {
+		t.Error("expected non-empty created_at from ChannelByID")
+	}
+	if ch.Name != "tschan" {
+		t.Errorf("expected name tschan, got %s", ch.Name)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/channels/{id}/info` endpoint returning channel details, bot name, subscriber list with usernames, and pinned message ID (#115)
- Expose `created_at` from channels table in `Channel` struct (was in DB schema but not in Go model)
- Add `ChannelSubscribersJoin()` store method (single JOIN query, no N+1)
- Add `hub *ws.Hub` to `AdminAPI` — broadcast `channel_rename` WS event when admin renames a channel (#116)
- 6 new tests (3 store, 3 API)

## Test plan
- [x] `TestChannelSubscribersJoin` — verifies JOIN returns sorted usernames
- [x] `TestChannelSubscribersJoin_Empty` — verifies empty result for no subscribers
- [x] `TestChannelByID_CreatedAt` — verifies created_at field populated
- [x] `TestChannelInfo` — full API integration test (auth, create channel, subscribe, verify response shape)
- [x] `TestChannelInfo_NotFound` — 404 for nonexistent channel
- [x] `TestChannelInfo_Unauthed` — 401 without token
- [x] Existing `TestAdminRenameChannel_Success` still passes (hub=nil is safe)

Closes #115, closes #116