### PR TITLE
fix: webhook routes to bot's first channel before creating alerts

### DIFF
--- a/internal/bot/webhook.go
+++ b/internal/bot/webhook.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/pusk-platform/pusk/internal/metrics"
+	"github.com/pusk-platform/pusk/internal/store"
 )
 
 // ── Per-bot webhook rate limiter ──
@@ -58,8 +59,10 @@ func webhookAllowed(token string) bool {
 //
 //	POST /hook/{token}?format=alertmanager|zabbix|grafana|raw
 //
-// The token is a bot token. Messages are sent to the first channel
-// owned by that bot, or to a channel specified by ?channel= param.
+// The token is a bot token. Messages are routed to:
+// 1. Channel specified by ?channel= param, or
+// 2. First existing channel owned by the bot, or
+// 3. Auto-created "alerts" channel (last resort).
 func (h *Handler) webhook(w http.ResponseWriter, r *http.Request) {
 	bot, err := h.authBot(r)
 	if err != nil {
@@ -129,14 +132,20 @@ func (h *Handler) webhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Find target channel
-	if channelName == "" {
-		channelName = "alerts" // default channel
+	// Find target channel:
+	// 1. Explicit ?channel= param
+	// 2. First channel owned by this bot
+	// 3. Auto-create "alerts" as last resort
+	var ch *store.Channel
+	if channelName != "" {
+		ch, err = s.ChannelByName(bot.ID, channelName)
+	} else {
+		ch, err = s.FirstChannelByBot(bot.ID)
 	}
-
-	ch, err := s.ChannelByName(bot.ID, channelName)
 	if err != nil {
-		// Try creating the channel
+		if channelName == "" {
+			channelName = "alerts"
+		}
 		ch, err = s.CreateChannel(bot.ID, channelName, "Webhook alerts")
 		if err != nil {
 			slog.Error("webhook channel create failed", "channel", channelName, "error", err)
@@ -144,7 +153,6 @@ func (h *Handler) webhook(w http.ResponseWriter, r *http.Request) {
 			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok", "error": "channel error"})
 			return
 		}
-		// Auto-subscribe admin (user_id=1) to new channel
 		_ = s.Subscribe(ch.ID, 1)
 		slog.Info("webhook auto-created channel", "channel", channelName, "bot", bot.Name)
 	}

--- a/internal/store/channels.go
+++ b/internal/store/channels.go
@@ -362,6 +362,14 @@ func (s *Store) RenameChannel(channelID int64, name string) error {
 	return err
 }
 
+// FirstChannelByBot returns the first channel owned by a bot (by creation order).
+func (s *Store) FirstChannelByBot(botID int64) (*Channel, error) {
+	ch := &Channel{}
+	err := s.db.QueryRow("SELECT id, bot_id, name, COALESCE(description,''), COALESCE(created_at,'') FROM channels WHERE bot_id=? ORDER BY id LIMIT 1",
+		botID).Scan(&ch.ID, &ch.BotID, &ch.Name, &ch.Description, &ch.CreatedAt)
+	return ch, err
+}
+
 // UpdateChannelBot changes the bot associated with a channel.
 func (s *Store) UpdateChannelBot(channelID, botID int64) error {
 	_, err := s.db.Exec("UPDATE channels SET bot_id=? WHERE id=?", botID, channelID)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1087,7 +1087,7 @@ func TestFirstChannelByBot_ReturnsOldest(t *testing.T) {
 	s := newTestStore(t)
 	bot, _ := s.CreateBot("fcb1", "FCBBot")
 	ch1, _ := s.CreateChannel(bot.ID, "first", "")
-	s.CreateChannel(bot.ID, "second", "")
+	_, _ = s.CreateChannel(bot.ID, "second", "")
 
 	got, err := s.FirstChannelByBot(bot.ID)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1082,3 +1082,31 @@ func TestChannelByID_CreatedAt(t *testing.T) {
 		t.Errorf("expected name tschan, got %s", ch.Name)
 	}
 }
+
+func TestFirstChannelByBot_ReturnsOldest(t *testing.T) {
+	s := newTestStore(t)
+	bot, _ := s.CreateBot("fcb1", "FCBBot")
+	ch1, _ := s.CreateChannel(bot.ID, "first", "")
+	s.CreateChannel(bot.ID, "second", "")
+
+	got, err := s.FirstChannelByBot(bot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != ch1.ID {
+		t.Errorf("expected channel id %d, got %d", ch1.ID, got.ID)
+	}
+	if got.Name != "first" {
+		t.Errorf("expected name first, got %s", got.Name)
+	}
+}
+
+func TestFirstChannelByBot_NoChannels(t *testing.T) {
+	s := newTestStore(t)
+	bot, _ := s.CreateBot("fcb2", "FCBBot2")
+
+	_, err := s.FirstChannelByBot(bot.ID)
+	if err == nil {
+		t.Error("expected error for bot with no channels")
+	}
+}


### PR DESCRIPTION
## Summary
- Webhooks without `?channel=` now route to the bot's **first existing channel** instead of always auto-creating an "alerts" channel
- Routing order: 1) explicit `?channel=` param → 2) first channel owned by bot → 3) auto-create "alerts" (last resort)
- Adds `Store.FirstChannelByBot()` method + 2 tests

## Context
Reported by Kust23 (K25): webhook creates duplicate "alerts" channels even when the bot already has channels configured.

## Test plan
- [x] `TestFirstChannelByBot_ReturnsOldest` — returns oldest channel by ID
- [x] `TestFirstChannelByBot_NoChannels` — returns error when bot has no channels
- [x] All 82 bot package tests pass
- [x] `go vet ./...` clean
- [x] `gofumpt` clean