### PR TITLE
ci: pin gofumpt v0.10.0, reformat code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           version: v2.11.4
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@latest
+        run: go install mvdan.cc/gofumpt@v0.10.0
       - name: gofumpt
         run: test -z "$(gofumpt -l .)"
       - name: JS syntax check

--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -223,7 +223,8 @@ func main() {
 	}
 
 	slog.Info("server starting", "addr", *addr)
-	slog.Info("routes",
+	slog.Info(
+		"routes",
 		"bot_api", "POST /bot{token}/sendMessage",
 		"client_api", "GET /api/health",
 		"pwa", "GET /",

--- a/internal/api/logging.go
+++ b/internal/api/logging.go
@@ -57,7 +57,8 @@ func RequestLogger(next http.Handler) http.Handler {
 			ip = r.RemoteAddr
 		}
 
-		slog.Info("http request",
+		slog.Info(
+			"http request",
 			"method", r.Method,
 			"path", path,
 			"status", sw.code,

--- a/internal/bot/leak_test.go
+++ b/internal/bot/leak_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
+	goleak.VerifyTestMain(
+		m,
 		goleak.IgnoreTopFunction("github.com/pusk-platform/pusk/internal/bot.init.0.func1"),
 	)
 }

--- a/internal/notify/push.go
+++ b/internal/notify/push.go
@@ -83,7 +83,8 @@ func (p *PushService) SendToUser(s *store.Store, userID int64, payload PushPaylo
 				_ = resp.Body.Close()
 			}
 			failed++
-			slog.Error("push send failed",
+			slog.Error(
+				"push send failed",
 				"user_id", userID,
 				"provider", pushProvider(sub.Endpoint),
 				"error", err,
@@ -103,7 +104,8 @@ func (p *PushService) SendToUser(s *store.Store, userID int64, payload PushPaylo
 		if resp.StatusCode == 401 || resp.StatusCode == 410 || resp.StatusCode == 404 || resp.StatusCode == 403 {
 			stale++
 			_ = s.DeletePushSubscription(sub.Endpoint)
-			slog.Info("push stale removed",
+			slog.Info(
+				"push stale removed",
 				"user_id", userID,
 				"provider", pushProvider(sub.Endpoint),
 				"status", resp.StatusCode,
@@ -113,7 +115,8 @@ func (p *PushService) SendToUser(s *store.Store, userID int64, payload PushPaylo
 		}
 	}
 
-	slog.Info("push delivered",
+	slog.Info(
+		"push delivered",
 		"user_id", userID,
 		"title", payload.Title,
 		"sent", sent,

--- a/internal/store/channels.go
+++ b/internal/store/channels.go
@@ -137,7 +137,8 @@ func (s *Store) SaveChannelMessageFrom(channelID int64, sender, senderName, text
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := s.db.Exec(
 		"INSERT INTO channel_messages (channel_id, sender, sender_name, text, reply_markup, file_id, file_type, created_at) VALUES (?,?,?,?,?,?,?,?)",
-		channelID, sender, senderName, text, replyMarkup, fileID, fileType, now)
+		channelID, sender, senderName, text, replyMarkup, fileID, fileType, now,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,8 @@ func (s *Store) SaveChannelMessageFrom(channelID int64, sender, senderName, text
 func (s *Store) ChannelMessages(channelID int64, limit int) ([]ChannelMessage, error) {
 	rows, err := s.db.Query(
 		"SELECT id, channel_id, COALESCE(sender,'bot'), COALESCE(sender_name,''), COALESCE(text,''), COALESCE(reply_markup,''), COALESCE(reply_to,0), COALESCE(file_id,''), COALESCE(file_type,''), created_at, COALESCE(edited_at,'') FROM channel_messages WHERE channel_id=? ORDER BY id DESC LIMIT ?",
-		channelID, limit)
+		channelID, limit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/invites.go
+++ b/internal/store/invites.go
@@ -16,7 +16,8 @@ func (s *Store) CreateInvite(code string, ttl time.Duration) error {
 func (s *Store) UseInvite(code string) error {
 	res, err := s.db.Exec(
 		"UPDATE invites SET uses=uses+1 WHERE code=? AND uses<COALESCE(max_uses,50) AND expires_at > ?",
-		code, time.Now().UTC().Format(time.RFC3339))
+		code, time.Now().UTC().Format(time.RFC3339),
+	)
 	if err != nil {
 		return fmt.Errorf("invite error")
 	}
@@ -65,7 +66,8 @@ func (s *Store) ActiveInvite() (string, error) {
 	var code string
 	err := s.db.QueryRow(
 		"SELECT code FROM invites WHERE COALESCE(uses,0)<COALESCE(max_uses,50) AND expires_at > ? ORDER BY created_at DESC LIMIT 1",
-		time.Now().UTC().Format(time.RFC3339)).Scan(&code)
+		time.Now().UTC().Format(time.RFC3339),
+	).Scan(&code)
 	if err != nil {
 		return "", nil //nolint:nilerr // sql.ErrNoRows means no active invite — not an error for callers
 	}

--- a/internal/store/leak_test.go
+++ b/internal/store/leak_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m,
+	goleak.VerifyTestMain(
+		m,
 		goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),
 	)
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -20,7 +20,8 @@ func (s *Store) SaveMessage(chatID int64, sender, text, replyMarkup, fileID, fil
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := s.db.Exec(
 		"INSERT INTO messages (chat_id, sender, text, reply_markup, file_id, file_type, created_at) VALUES (?,?,?,?,?,?,?)",
-		chatID, sender, text, replyMarkup, fileID, fileType, now)
+		chatID, sender, text, replyMarkup, fileID, fileType, now,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +35,8 @@ func (s *Store) SaveMessage(chatID int64, sender, text, replyMarkup, fileID, fil
 func (s *Store) GetMessage(id int64) (*Message, error) {
 	m := &Message{}
 	err := s.db.QueryRow(
-		"SELECT id, chat_id, sender, COALESCE(text,''), COALESCE(reply_markup,''), COALESCE(file_id,''), COALESCE(file_type,''), created_at FROM messages WHERE id=?", id).
+		"SELECT id, chat_id, sender, COALESCE(text,''), COALESCE(reply_markup,''), COALESCE(file_id,''), COALESCE(file_type,''), created_at FROM messages WHERE id=?", id,
+	).
 		Scan(&m.ID, &m.ChatID, &m.Sender, &m.Text, &m.ReplyMarkup, &m.FileID, &m.FileType, &m.CreatedAt)
 	return m, err
 }
@@ -52,7 +54,8 @@ func (s *Store) DeleteMessage(id int64) error {
 func (s *Store) ChatMessages(chatID int64, limit int) ([]Message, error) {
 	rows, err := s.db.Query(
 		"SELECT id, chat_id, sender, COALESCE(text,''), COALESCE(reply_markup,''), COALESCE(file_id,''), COALESCE(file_type,''), created_at FROM messages WHERE chat_id=? ORDER BY created_at DESC LIMIT ?",
-		chatID, limit)
+		chatID, limit,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Pin `gofumpt` to `v0.10.0` in CI (was `@latest` which broke after v0.10.0 release)
- Reformat 8 Go files to satisfy new gofumpt rules (trailing commas, arg-per-line in multi-line calls)
- Unblocks PR #128 and all future PRs

## Context
`gofumpt v0.10.0` (released after May 1) enforces stricter formatting for multi-line function calls. CI used `@latest`, so any PR now fails the `gofumpt` check even though the code itself is unchanged.

## Test plan
- [x] CI Build & Lint passes (gofumpt step green)
- [x] No functional changes — purely cosmetic formatting