### PR TITLE
docs: fix license domain, security versions, llms.txt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,7 +14,7 @@ Additional Use Grant: You may make production use of the Licensed Work,
                       provided that you do not use the Licensed Work to
                       offer a hosted or managed bot platform service to
                       third parties that competes with the Licensor's
-                      official hosted offering at getpusk.com, without
+                      official hosted offering at getpusk.ru, without
                       a separate commercial agreement with the Licensor.
 Change Date:          2030-03-17
 Change License:       MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.5.x   | :white_check_mark: |
-| < 0.5   | :x:                |
+| 0.7.x   | :white_check_mark: |
+| < 0.7   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/llms.txt
+++ b/llms.txt
@@ -120,8 +120,7 @@ docker run -d --name pusk \
   -v pusk-data:/app/data \
   ghcr.io/getpusk/pusk:latest
 
-# Docker Compose
-curl -O https://raw.githubusercontent.com/getpusk/pusk/main/docker-compose.yml
+# Docker Compose (see README for full docker-compose.yml)
 docker compose up -d
 
 # From source


### PR DESCRIPTION
## Summary
- LICENSE: `getpusk.com` → `getpusk.ru` (actual domain in Additional Use Grant)
- SECURITY.md: supported versions `0.5.x` → `0.7.x`
- llms.txt: remove `curl` to non-existent `docker-compose.yml`