### PR TITLE
fix(store): apply SQLite pragmas via DSN and enforce foreign keys

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -21,20 +22,56 @@ type Store struct {
 
 // New opens (or creates) the SQLite database at path and runs migrations.
 func New(path string) (*Store, error) {
-	db, err := sql.Open("sqlite", path+"?_journal_mode=WAL&_busy_timeout=5000")
+	// modernc.org/sqlite only honors the "_pragma" DSN key; mattn-style keys
+	// (_journal_mode, _busy_timeout) are silently ignored. Pragmas set this way
+	// are applied to every pooled connection, unlike a one-shot db.Exec which
+	// would only configure whichever connection happened to run it.
+	dsn := path + "?" + strings.Join([]string{
+		"_pragma=busy_timeout(5000)",
+		"_pragma=journal_mode(WAL)",
+		"_pragma=synchronous(NORMAL)",
+		"_pragma=journal_size_limit(67108864)", // 64MB
+		"_pragma=foreign_keys(1)",
+	}, "&")
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
-	db.SetMaxOpenConns(4) // WAL mode allows concurrent reads; single writer enforced by WAL
-	//nolint:errcheck // best-effort PRAGMA tuning — defaults are safe
-	db.Exec("PRAGMA journal_size_limit = 67108864") // 64MB
-	//nolint:errcheck // best-effort PRAGMA tuning
-	db.Exec("PRAGMA synchronous = NORMAL")
+	db.SetMaxOpenConns(4) // WAL allows concurrent readers; busy_timeout serializes writers
 	s := &Store{db: db}
+	if err := s.verifyPragmas(path); err != nil {
+		db.Close() //nolint:errcheck // returning the original error
+		return nil, err
+	}
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return s, nil
+}
+
+// verifyPragmas confirms the runtime PRAGMAs from the DSN actually took effect.
+// The driver applies them silently, so a typo or driver change could leave the
+// database in DELETE-journal mode with foreign keys off without any error at
+// open — exactly the regression this guards against.
+func (s *Store) verifyPragmas(path string) error {
+	var fk int
+	if err := s.db.QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil {
+		return fmt.Errorf("read foreign_keys pragma: %w", err)
+	}
+	if fk != 1 {
+		return fmt.Errorf("foreign_keys not enabled (got %d): DSN pragmas were not applied", fk)
+	}
+	// WAL is a file-level mode; in-memory databases always report "memory".
+	if path != ":memory:" {
+		var mode string
+		if err := s.db.QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+			return fmt.Errorf("read journal_mode pragma: %w", err)
+		}
+		if !strings.EqualFold(mode, "wal") {
+			return fmt.Errorf("journal_mode is %q, want wal: DSN pragmas were not applied", mode)
+		}
+	}
+	return nil
 }
 
 // Close closes the underlying database connection.

--- a/internal/store/store_pragmas_test.go
+++ b/internal/store/store_pragmas_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPragmasApplied asserts that the DSN pragmas actually take effect on a
+// file-backed database: WAL journal, foreign keys on, and a non-zero busy
+// timeout. This is the regression guard for the silently-ignored mattn-style
+// DSN keys (issue #146).
+func TestPragmasApplied(t *testing.T) {
+	s, err := New(t.TempDir() + "/pragma.db")
+	if err != nil {
+		t.Fatalf("New(file): %v", err)
+	}
+	defer func() { _ = s.Close() }()
+
+	var mode string
+	if err := s.DB().QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if !strings.EqualFold(mode, "wal") {
+		t.Errorf("journal_mode = %q, want wal", mode)
+	}
+
+	var fk int
+	if err := s.DB().QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatalf("read foreign_keys: %v", err)
+	}
+	if fk != 1 {
+		t.Errorf("foreign_keys = %d, want 1", fk)
+	}
+
+	var busy int
+	if err := s.DB().QueryRow("PRAGMA busy_timeout").Scan(&busy); err != nil {
+		t.Fatalf("read busy_timeout: %v", err)
+	}
+	if busy != 5000 {
+		t.Errorf("busy_timeout = %d, want 5000", busy)
+	}
+}
+
+// TestForeignKeysEnforced proves foreign key constraints are enforced at
+// runtime: inserting a child row whose parents do not exist must fail. Before
+// #146 the REFERENCES clauses were inert and this insert silently succeeded.
+func TestForeignKeysEnforced(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.DB().Exec(
+		"INSERT INTO chats (user_id, bot_id) VALUES (999999, 888888)",
+	); err == nil {
+		t.Fatal("expected FK violation inserting chat with missing user/bot, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

The store DSN used mattn-style keys (`_journal_mode`, `_busy_timeout`) that `modernc.org/sqlite` silently ignores — only the `_pragma` form is honored. As a result the database ran in the default DELETE rollback journal with `busy_timeout=0` and foreign keys disabled, despite the comment claiming WAL with a single writer.

This switches to the `_pragma` form the driver actually applies (to **every** pooled connection, not just whichever one ran a one-shot `db.Exec`), and adds a startup assertion so a future typo or driver change fails loudly instead of silently degrading durability.

Fixes #146.

## Changes

- `internal/store/store.go`
  - DSN now sets `busy_timeout(5000)`, `journal_mode(WAL)`, `synchronous(NORMAL)`, `journal_size_limit(64MB)`, `foreign_keys(1)` via `_pragma`.
  - New `verifyPragmas()` asserts at startup that `foreign_keys` is on and (for file-backed DBs) `journal_mode` is `wal`; returns an error otherwise.
  - Removed the two one-shot `PRAGMA` `db.Exec` calls (only configured a single pooled connection) and the misleading WAL comment.
- `internal/store/store_pragmas_test.go` (new)
  - `TestPragmasApplied` — asserts WAL, `foreign_keys=1`, `busy_timeout=5000` on a file-backed DB.
  - `TestForeignKeysEnforced` — inserting a `chats` row with non-existent parents now fails.

## Why this is safe to enable foreign keys

The hand-rolled cascade deletes already remove children before parents (`DeleteChannel`, `DeleteUser`), and `DeleteBot` refuses when a bot still owns channels. Enabling enforcement is therefore compatible with every existing path.

Also closes the related items from the audit tracking issue: per-connection PRAGMA gap (STORE-2) and the previously-inert `REFERENCES` constraints (STORE-3).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- `go test ./... -race -count=1` — green across all packages (api, auth, bot, org, store, ws) on `modernc.org/sqlite` v1.50.1.