### PR TITLE
fix(api): require admin token to create organizations

### DIFF
--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -139,7 +139,11 @@ func main() {
 
 	adminToken := os.Getenv("PUSK_ADMIN_TOKEN")
 	if adminToken == "" {
-		slog.Warn("PUSK_ADMIN_TOKEN not set — org creation is unprotected, set it for production use")
+		if os.Getenv("PUSK_DEMO") == "1" {
+			slog.Warn("PUSK_ADMIN_TOKEN not set — org registration is open (demo mode sandbox)")
+		} else {
+			slog.Warn("PUSK_ADMIN_TOKEN not set — org registration and the admin API are disabled; set it to create organizations")
+		}
 	}
 
 	mux := http.NewServeMux()

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -372,7 +372,10 @@ func (a *AdminAPI) orgInfo(w http.ResponseWriter, r *http.Request) {
 			userOrgs++
 		}
 	}
-	canCreate := a.orgs.CanCreateOrg()
+	// In production org creation requires the global admin token; demo mode is
+	// an open sandbox. The landing page hides the create-org button when this is
+	// false, so anonymous visitors are never shown a control that would 401.
+	canCreate := (a.DemoMode || a.isGlobalAdmin(r)) && a.orgs.CanCreateOrg()
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"can_create_org": canCreate,
@@ -382,9 +385,15 @@ func (a *AdminAPI) orgInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *AdminAPI) registerOrg(w http.ResponseWriter, r *http.Request) {
-	// Enforce org limit unless caller has admin token
-	if !a.orgs.CanCreateOrg() && !a.isGlobalAdmin(r) {
-		jsonErr(w, "org registration disabled — limit reached", http.StatusForbidden)
+	// Org creation is an instance-level operation: in production it requires the
+	// global admin token. When PUSK_ADMIN_TOKEN is unset, isGlobalAdmin is false
+	// and registration is refused — consistent with resetPassword/deleteOrg.
+	// Otherwise any anonymous client could create the first org on a default
+	// deployment and receive an admin token (pre-auth privilege escalation).
+	// Demo mode is an open sandbox (guest login, seeded data) and keeps the
+	// self-serve registration flow.
+	if !a.DemoMode && !a.isGlobalAdmin(r) {
+		jsonErr(w, "org registration requires admin authentication", http.StatusUnauthorized)
 		return
 	}
 
@@ -406,6 +415,8 @@ func (a *AdminAPI) registerOrg(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"password must be at least 8 characters"}`, 400)
 		return
 	}
+	// A global admin may exceed the MaxOrgs limit; demo registrations stay
+	// subject to it (demo runs with PUSK_MAX_ORGS=0, i.e. unlimited).
 	if err := a.orgs.Register(req.Slug, req.Name, req.Username, req.Pin, a.isGlobalAdmin(r)); err != nil {
 		jsonErr(w, err.Error(), 400)
 		return

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -85,7 +85,7 @@ func TestAdminRegisterOrg_Success(t *testing.T) {
 	env := newAdminEnv(t)
 	rec := env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "neworg", "name": "New Org", "username": "admin", "pin": "admin12345",
-	}, "")
+	}, env.token)
 	if rec.Code != 200 {
 		t.Fatalf("register org: got %d, body: %s", rec.Code, rec.Body.String())
 	}
@@ -108,7 +108,7 @@ func TestAdminRegisterOrg_MissingFields(t *testing.T) {
 	env := newAdminEnv(t)
 	rec := env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "x",
-	}, "")
+	}, env.token)
 	if rec.Code != 400 {
 		t.Fatalf("register org missing fields: got %d, want 400", rec.Code)
 	}
@@ -118,7 +118,7 @@ func TestAdminRegisterOrg_ShortPin(t *testing.T) {
 	env := newAdminEnv(t)
 	rec := env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "shortpin", "username": "admin", "pin": "abc",
-	}, "")
+	}, env.token)
 	if rec.Code != 400 {
 		t.Fatalf("register org short pin: got %d, want 400", rec.Code)
 	}
@@ -128,12 +128,88 @@ func TestAdminRegisterOrg_Duplicate(t *testing.T) {
 	env := newAdminEnv(t)
 	env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "duporg", "name": "Dup", "username": "admin", "pin": "admin12345",
-	}, "")
+	}, env.token)
 	rec := env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "duporg", "name": "Dup2", "username": "admin2", "pin": "admin12345",
-	}, "")
+	}, env.token)
 	if rec.Code != 400 {
 		t.Fatalf("register org duplicate: got %d, want 400", rec.Code)
+	}
+}
+
+// TestAdminRegisterOrg_NoAuth verifies the SEC-1 fix: an anonymous client can
+// no longer create an org (which previously handed out an admin token).
+func TestAdminRegisterOrg_NoAuth(t *testing.T) {
+	env := newAdminEnv(t)
+	rec := env.doReq("POST", "/api/org/register", map[string]string{
+		"slug": "anon", "name": "Anon", "username": "admin", "pin": "admin12345",
+	}, "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous register: got %d, want 401", rec.Code)
+	}
+	if _, err := env.orgs.Get("anon"); err == nil {
+		t.Error("anonymous register must not create the org")
+	}
+}
+
+func TestAdminRegisterOrg_WrongToken(t *testing.T) {
+	env := newAdminEnv(t)
+	rec := env.doReq("POST", "/api/org/register", map[string]string{
+		"slug": "wrong", "name": "Wrong", "username": "admin", "pin": "admin12345",
+	}, "not-the-admin-token")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong-token register: got %d, want 401", rec.Code)
+	}
+}
+
+// TestAdminRegisterOrg_NoAdminTokenConfigured covers the default deployment:
+// with PUSK_ADMIN_TOKEN unset, registration is refused outright rather than
+// silently allowing the first anonymous caller to become admin.
+func TestAdminRegisterOrg_NoAdminTokenConfigured(t *testing.T) {
+	env := newAdminEnv(t)
+	env.admin.adminToken = "" // server started without PUSK_ADMIN_TOKEN
+	rec := env.doReq("POST", "/api/org/register", map[string]string{
+		"slug": "noatoken", "name": "X", "username": "admin", "pin": "admin12345",
+	}, "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("register with no admin token configured: got %d, want 401", rec.Code)
+	}
+}
+
+// TestAdminRegisterOrg_DemoModeAllowsAnon confirms demo mode keeps the open
+// self-serve flow the e2e/integration harness relies on.
+func TestAdminRegisterOrg_DemoModeAllowsAnon(t *testing.T) {
+	env := newAdminEnv(t)
+	env.admin.DemoMode = true
+	rec := env.doReq("POST", "/api/org/register", map[string]string{
+		"slug": "demoorg", "name": "Demo", "username": "admin", "pin": "admin12345",
+	}, "")
+	if rec.Code != 200 {
+		t.Fatalf("demo-mode anonymous register: got %d, want 200, body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAdminOrgInfo_CanCreateRequiresAdmin verifies the landing page only shows
+// the create-org button to a global admin (can_create_org is admin-aware).
+func TestAdminOrgInfo_CanCreateRequiresAdmin(t *testing.T) {
+	env := newAdminEnv(t)
+
+	rec := env.doReq("GET", "/api/org/info", nil, "")
+	var anon map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &anon); err != nil {
+		t.Fatal(err)
+	}
+	if anon["can_create_org"] != false {
+		t.Errorf("anonymous can_create_org = %v, want false", anon["can_create_org"])
+	}
+
+	rec = env.doReq("GET", "/api/org/info", nil, env.token)
+	var adm map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &adm); err != nil {
+		t.Fatal(err)
+	}
+	if adm["can_create_org"] != true {
+		t.Errorf("admin can_create_org = %v, want true", adm["can_create_org"])
 	}
 }
 
@@ -181,7 +257,7 @@ func TestAdminRegisterBot_WithJWT(t *testing.T) {
 	// Register org to get JWT admin token
 	rec := env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "botorg", "name": "BotOrg", "username": "admin", "pin": "admin12345",
-	}, "")
+	}, env.token)
 	var orgResp map[string]interface{}
 	if err := json.Unmarshal(rec.Body.Bytes(), &orgResp); err != nil {
 		t.Fatal(err)
@@ -541,7 +617,7 @@ func TestAdminResetPassword_Success(t *testing.T) {
 	env := newAdminEnv(t)
 	env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "rporg", "name": "RP", "username": "user1", "pin": "oldpass123",
-	}, "")
+	}, env.token)
 
 	rec := env.doReq("POST", "/admin/reset-password", map[string]interface{}{
 		"org": "rporg", "username": "user1", "new_pin": "newpass789",
@@ -604,7 +680,7 @@ func TestAdminSetRole_Success(t *testing.T) {
 	env := newAdminEnv(t)
 	rec := env.doReq("POST", "/api/org/register", map[string]string{
 		"slug": "srorg", "name": "SR", "username": "user1", "pin": "pass123456",
-	}, "")
+	}, env.token)
 	var orgResp map[string]interface{}
 	if err := json.Unmarshal(rec.Body.Bytes(), &orgResp); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

`POST /api/org/register` was gated only by the org-count limit (`CanCreateOrg()`), not by authentication. On a default deployment (`PUSK_ADMIN_TOKEN` unset, `PUSK_MAX_ORGS=1`) any anonymous client could create the first organization and receive a `role:admin` JWT — a pre-auth privilege escalation. It also lets an attacker land-grab the single org slot and lock the legitimate operator out. The README already documents this endpoint as admin-only (`Authorization: Bearer <PUSK_ADMIN_TOKEN>` or an admin JWT); the code did not enforce it.

Fixes #148.

## Change

- **`internal/api/admin.go`**
  - `registerOrg` now requires the global admin token: `if !a.DemoMode && !a.isGlobalAdmin(r) → 401`. When `PUSK_ADMIN_TOKEN` is unset, `isGlobalAdmin` is false and registration is refused — consistent with `resetPassword`/`deleteOrg`, which already fail closed.
  - `orgInfo`'s `can_create_org` is now admin-aware (`(DemoMode || isGlobalAdmin) && CanCreateOrg()`). The landing page already hides the create-org button when this is `false` (`web/static/js/landing.js:72`), so anonymous visitors are no longer shown a control that would 401 — no JS change needed.
- **`cmd/pusk/main.go`** — the `PUSK_ADMIN_TOKEN not set` startup warning now describes the real behavior (registration disabled in production; open in demo).

## Demo mode is intentionally preserved

The e2e and integration suites, and the documented "open localhost:8443 → create an organization" flow, bootstrap via anonymous registration. They run in **demo mode** (`PUSK_DEMO=1`, `-tags demo`), which is already an open sandbox (guest login, seeded data). Demo mode therefore keeps anonymous registration; only production (non-demo) requires the token. This closes the hole without breaking the test harness or the self-serve demo.

## Tests

- New: anonymous → 401, wrong token → 401, no admin token configured → 401, demo mode → 200, and `can_create_org` admin-aware.
- Updated the existing admin register/reset-password/set-role fixtures to authenticate with the admin token.
- `go build ./...` and `go build -tags demo`, `go vet ./...`, `golangci-lint` (0 issues), `gofmt` — clean.
- `go test ./... -race -shuffle=on` — green across all packages.

## Note

`docs/use-cases.*.md` describe "open the UI → create an organization" for a self-hoster; in production that now requires `PUSK_ADMIN_TOKEN`. The API reference in `README.md` already states this. Happy to add a one-line note to the use-case docs if preferred.