### PR TITLE
fix(notify): bound Web Push requests with an HTTP client timeout

### DIFF
--- a/internal/notify/push.go
+++ b/internal/notify/push.go
@@ -5,11 +5,18 @@ package notify
 import (
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"strings"
+	"time"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
 	"github.com/pusk-platform/pusk/internal/store"
 )
+
+// pushTimeout bounds a single Web Push HTTP request. Without it webpush-go uses
+// a client with no timeout, so a slow/hung push provider can block the caller
+// (the webhook ingest goroutine) until the OS TCP timeout — minutes.
+const pushTimeout = 10 * time.Second
 
 // PushService sends Web Push notifications.
 // It no longer holds a store reference; callers pass the org store per-request.
@@ -17,11 +24,22 @@ type PushService struct {
 	vapidPub   string
 	vapidPriv  string
 	vapidEmail string
+	httpClient *http.Client
 }
 
 func NewPushService(vapidPub, vapidPriv, email string) *PushService {
 	return &PushService{
 		vapidPub: vapidPub, vapidPriv: vapidPriv, vapidEmail: email,
+		// One shared client with a timeout and a pooled transport, reused across
+		// all sends instead of webpush-go's default zero-timeout client.
+		httpClient: &http.Client{
+			Timeout: pushTimeout,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
 	}
 }
 
@@ -72,6 +90,7 @@ func (p *PushService) SendToUser(s *store.Store, userID int64, payload PushPaylo
 		}
 
 		resp, err := webpush.SendNotification(data, wps, &webpush.Options{
+			HTTPClient:      p.httpClient,
 			Subscriber:      p.vapidEmail,
 			VAPIDPublicKey:  p.vapidPub,
 			VAPIDPrivateKey: p.vapidPriv,

--- a/internal/notify/push_test.go
+++ b/internal/notify/push_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package notify
+
+import "testing"
+
+// TestNewPushServiceHasHTTPTimeout locks in the PERF-1/REL-3 fix: the push
+// client must have a non-zero timeout so a hung provider cannot block the
+// caller indefinitely.
+func TestNewPushServiceHasHTTPTimeout(t *testing.T) {
+	p := NewPushService("pub", "priv", "mailto:ops@example.com")
+	if p.httpClient == nil {
+		t.Fatal("httpClient is nil — sends would use webpush-go's zero-timeout default")
+	}
+	if p.httpClient.Timeout != pushTimeout {
+		t.Errorf("httpClient.Timeout = %v, want %v", p.httpClient.Timeout, pushTimeout)
+	}
+}
+
+// TestSendToUserNoConfigNoop verifies SendToUser is a cheap no-op when push is
+// not configured (empty VAPID key), so the async fan-out goroutine costs
+// nothing in that common case.
+func TestSendToUserNoConfigNoop(t *testing.T) {
+	p := NewPushService("", "", "")
+	// Must not panic or block; store is unused because it returns before any
+	// lookup when the VAPID public key is empty.
+	p.SendToUser(nil, 1, PushPayload{Title: "x", Body: "y"})
+}


### PR DESCRIPTION
## Summary

`webpush.SendNotification` was called with no `Options.HTTPClient`, so webpush-go fell back to a client with **no timeout**. A slow or hung push provider (FCM / Mozilla / Yandex) could block the calling goroutine until the OS TCP timeout — minutes. This is especially bad on the webhook ingest path: `pushChannelMessage` fans out push synchronously before the handler returns `200` to Alertmanager/Grafana, so a degraded provider stalls alert ingestion and the source retries or drops the alert.

`PushService` now holds one shared `*http.Client` with a 10s timeout and a pooled transport, passed as `Options.HTTPClient` and reused across all sends. Each request is time-bounded, and connections are reused instead of dialed per call.

Refs #147 (REL-3 / PERF-1).

## Change
- `internal/notify/push.go` — add `httpClient *http.Client` (`Timeout: 10s`, pooled `Transport`) to `PushService`; pass it in `webpush.Options`.
- `internal/notify/push_test.go` (new) — assert the client has the timeout; assert `SendToUser` is a no-op when push is unconfigured.

## Scope
This is the first of two parts. It caps the **unbounded blocking** (the worst of REL-3). A follow-up will move the push fan-out fully **off** the request goroutine (bounded dispatch) so ingestion never waits on push at all, and will clean up some latent `staticcheck` SA5011 nil-checks in `internal/bot` that re-analysis of that package surfaces.

## Testing
- `go build ./...`, `go vet ./...`, `golangci-lint run ./internal/notify/...` (0 issues), `gofmt` — clean.
- `go test ./... -race -shuffle=on` — green across all packages.

Verified `webpush.Options.HTTPClient` is the documented interface field (`HTTPClient interface { Do(*http.Request) (*http.Response, error) }`, webpush-go v1.4.0), which `*http.Client` satisfies.