### PR TITLE
fix(bot): dispatch channel push fan-out off the request goroutine

### DIFF
--- a/internal/bot/handler.go
+++ b/internal/bot/handler.go
@@ -648,21 +648,35 @@ func (h *Handler) pushChannelMessage(s *store.Store, ch *store.Channel, bot *sto
 		"channel_name": ch.Name,
 		"bot_name":     bot.Name,
 	})
-	// WS broadcast to all org users (so unsubscribed users get badge updates)
+	// WS broadcast to all org users (so unsubscribed users get badge updates).
+	// In-memory and fast, so it stays on the caller's goroutine.
 	h.hub.SendToOrg(s.OrgID, ws.Event{Type: "channel_message", ChatID: ch.ID, Payload: payload}, "")
-	// Push notifications only to offline subscribers
-	subs, _ := s.ChannelSubscribers(ch.ID)
-	for _, userID := range subs {
-		key := s.OrgID + ":" + fmt.Sprintf("%d", userID)
-		if !h.hub.IsConnected(key) {
-			h.push.SendToUser(s, userID, notify.PushPayload{
-				Title: "#" + ch.Name,
-				Body:  truncate(msg.Text, 100),
-				Tag:   fmt.Sprintf("ch-%d-%d", ch.ID, msg.ID),
-				URL:   fmt.Sprintf("/?channel=%d&org=%s", ch.ID, s.OrgID),
-			})
+
+	// Push fan-out talks to external providers (FCM/Mozilla/Yandex). On the
+	// webhook ingest path this runs before the 200 returned to the monitoring
+	// system, so a slow provider would delay alert ingestion. Dispatch it off
+	// the caller's goroutine; each send is already time-bounded by the push
+	// HTTP client. The store and hub are process-lived, so they are safe to use
+	// after the request returns.
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic in channel push fan-out", "panic", r, "channel", ch.Name)
+			}
+		}()
+		subs, _ := s.ChannelSubscribers(ch.ID)
+		for _, userID := range subs {
+			key := s.OrgID + ":" + fmt.Sprintf("%d", userID)
+			if !h.hub.IsConnected(key) {
+				h.push.SendToUser(s, userID, notify.PushPayload{
+					Title: "#" + ch.Name,
+					Body:  truncate(msg.Text, 100),
+					Tag:   fmt.Sprintf("ch-%d-%d", ch.ID, msg.ID),
+					URL:   fmt.Sprintf("/?channel=%d&org=%s", ch.ID, s.OrgID),
+				})
+			}
 		}
-	}
+	}()
 }
 
 // ── Channel handlers ──

--- a/internal/bot/relay_test.go
+++ b/internal/bot/relay_test.go
@@ -8,9 +8,6 @@ import (
 
 func TestNewRelayHub(t *testing.T) {
 	rh := NewRelayHub()
-	if rh == nil {
-		t.Fatal("expected non-nil hub")
-	}
 	if rh.conns == nil {
 		t.Fatal("expected non-nil conns map")
 	}

--- a/internal/bot/updates_test.go
+++ b/internal/bot/updates_test.go
@@ -10,9 +10,6 @@ import (
 
 func TestNewUpdateQueue(t *testing.T) {
 	q := NewUpdateQueue()
-	if q == nil {
-		t.Fatal("expected non-nil queue")
-	}
 	if q.channels == nil {
 		t.Fatal("expected non-nil channels map")
 	}

--- a/internal/org/manager_test.go
+++ b/internal/org/manager_test.go
@@ -39,9 +39,6 @@ func TestGet_Default(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s == nil {
-		t.Fatal("expected non-nil store")
-	}
 	if s.OrgID != "default" {
 		t.Fatalf("OrgID = %q, want default", s.OrgID)
 	}


### PR DESCRIPTION
## Summary

`pushChannelMessage` fanned out Web Push **synchronously**. On the webhook ingest path (`webhook.go` → `pushChannelMessage`) it runs before the handler returns `200` to Alertmanager/Grafana, so ingestion waited on every offline subscriber's push round-trip.

This moves the push fan-out into a recover-guarded goroutine. The WS broadcast (in-memory) stays on the caller's goroutine. Combined with the push HTTP client timeout from #162, alert ingestion no longer blocks on push delivery at all.

This is Layer 2 of the PERF-1 / REL-3 fix (Layer 1 = #162). **Closes #147.**

## Change
- `internal/bot/handler.go` — push loop in `pushChannelMessage` now runs in a `go func()` with `defer recover()` (logs + swallows a panic so one bad fan-out can't crash the process). The store and hub are process-lived, so they remain valid after the request returns.
- Drive-by lint cleanup: removed redundant `if x == nil { t.Fatal }` checks that `staticcheck` (SA5011) flags once these packages are re-analysed — `NewRelayHub` / `NewUpdateQueue` / `Manager.Get` never return nil on success, and the following field access already proves non-nil. (`relay_test.go`, `updates_test.go`, `org/manager_test.go`)

## Notes
- A bounded worker pool (instead of one goroutine per alert) would be the next refinement under high alert volume; deferred. Each send is already time-bounded by the #162 client timeout, and one goroutine per alert matches the existing async pattern in `client_chat.go`.

## Testing
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (**0 issues**, down from 6 pre-existing SA5011), `gofmt` — clean.
- `go test ./... -race -shuffle=on` — green across all packages; `goleak` (bot package) does not flag the new goroutine.