### PR TITLE
fix(org): log only a bot-token prefix on org creation

### DIFF
--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -255,7 +255,10 @@ func (m *Manager) Register(slug, name, adminUser, adminPin string, bypassLimit b
 			}
 		}
 
-		slog.Info("org system bot created", "bot", sysBot.Name, "token", botToken)
+		// Log only a token prefix — the full token is the sole credential for
+		// /bot/<token> and the inbound /hook/<token>, and logs are routinely
+		// shipped/aggregated. Matches registerBot's "token_prefix" convention.
+		slog.Info("org system bot created", "bot", sysBot.Name, "token_prefix", botToken[:8])
 	}
 
 	m.orgs = append(m.orgs, Org{


### PR DESCRIPTION
## Summary

`org.Manager.Register` logged the freshly generated **system-bot token in full**:

```go
slog.Info("org system bot created", "bot", sysBot.Name, "token", botToken)
```

That token is the sole credential for `POST /bot/<token>/sendMessage` **and** the inbound alert webhook `/hook/<token>`. Anyone with access to log streams (journald, log aggregation, container stdout, CI) could read it and fully impersonate the bot. This also contradicts the project's own convention — `registerBot` already logs only `token_prefix` (`admin.go:121`).

Now logs only the first 8 hex chars.

Closes #150 (SEC-3).

## Scope note
The welcome DM still includes the token. That is the intended one-time delivery of the credential to the authenticated org owner, and the token already lives in plaintext in the `bots` table (it must, to route requests), so the DM adds no exposure beyond the database. The log line was the only path that exported it *outside* the database.

## Testing
- `botToken` is `hex.EncodeToString(make([]byte,16))` → 32 chars, so `[:8]` is always safe.
- `go build ./...`, `go vet`, `golangci-lint` (0 issues), `gofmt`, `go test ./internal/org/...` — clean/green.