### PR TITLE
fix(api): require channel membership to read messages, info, readers, ack

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -796,3 +796,38 @@ func TestChannelInfo_Unauthed(t *testing.T) {
 		t.Fatalf("channel info unauthed: got %d, want 401", rec.Code)
 	}
 }
+
+// TestChannelRead_RequiresMembership covers API-1: the read/ack endpoints must
+// reject a caller who is not subscribed to the channel (previously any org
+// member could read history/subscribers/readers and write acks).
+func TestChannelRead_RequiresMembership(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Register the caller first: register auto-subscribes the user to all
+	// *existing* channels, so a channel created afterwards has no subscription.
+	reg := env.request("POST", "/api/register", map[string]string{
+		"username": "outsider", "pin": "pass123456",
+	})
+	token := decodeJSON(t, reg)["token"].(string)
+
+	s, _ := env.orgs.Get("default")
+	bot, _ := s.CreateBot("tok-mem-api", "MemBot")
+	ch, _ := s.CreateChannel(bot.ID, "private-chan", "")
+
+	base := fmt.Sprintf("/api/channels/%d", ch.ID)
+	cases := []struct {
+		method, path string
+		body         interface{}
+	}{
+		{"GET", base + "/messages", nil},
+		{"GET", base + "/info", nil},
+		{"GET", base + "/readers", nil},
+		{"POST", base + "/ack", map[string]interface{}{"message_id": 1, "action": "ack"}},
+	}
+	for _, c := range cases {
+		rec := env.authedRequest(c.method, c.path, c.body, token)
+		if rec.Code != 403 {
+			t.Errorf("%s %s: got %d, want 403 (not subscribed)", c.method, c.path, rec.Code)
+		}
+	}
+}

--- a/internal/api/client_channels.go
+++ b/internal/api/client_channels.go
@@ -41,6 +41,10 @@ func (a *ClientAPI) channelInfo(w http.ResponseWriter, r *http.Request) {
 		jsonErr(w, "channel not found", 404)
 		return
 	}
+	if !s.IsSubscribed(channelID, UserIDFromCtx(r.Context())) {
+		jsonErr(w, "not subscribed", 403)
+		return
+	}
 
 	botName := ""
 	if bot, berr := s.BotByID(ch.BotID); berr == nil && bot != nil {
@@ -70,6 +74,10 @@ func (a *ClientAPI) channelInfo(w http.ResponseWriter, r *http.Request) {
 func (a *ClientAPI) channelReaders(w http.ResponseWriter, r *http.Request) {
 	channelID, _ := strconv.ParseInt(r.PathValue("channelID"), 10, 64)
 	s := a.db(r)
+	if !s.IsSubscribed(channelID, UserIDFromCtx(r.Context())) {
+		jsonErr(w, "not subscribed", 403)
+		return
+	}
 	readers, err := s.ChannelReadersJoin(channelID)
 	if err != nil {
 		jsonErr(w, "internal error", 500)
@@ -84,6 +92,11 @@ func (a *ClientAPI) channelReaders(w http.ResponseWriter, r *http.Request) {
 func (a *ClientAPI) ackChannelMessage(w http.ResponseWriter, r *http.Request) {
 	channelID, _ := strconv.ParseInt(r.PathValue("channelID"), 10, 64)
 	s := a.db(r)
+
+	if !s.IsSubscribed(channelID, UserIDFromCtx(r.Context())) {
+		jsonErr(w, "not subscribed", 403)
+		return
+	}
 
 	var req struct {
 		MessageID int64  `json:"message_id"`
@@ -182,6 +195,10 @@ func (a *ClientAPI) unsubscribe(w http.ResponseWriter, r *http.Request) {
 func (a *ClientAPI) channelMessages(w http.ResponseWriter, r *http.Request) {
 	channelID, _ := strconv.ParseInt(r.PathValue("channelID"), 10, 64)
 	s := a.db(r)
+	if !s.IsSubscribed(channelID, UserIDFromCtx(r.Context())) {
+		jsonErr(w, "not subscribed", 403)
+		return
+	}
 	limit := 50
 	if l := r.URL.Query().Get("limit"); l != "" {
 		limit, _ = strconv.Atoi(l)


### PR DESCRIPTION
## Summary

`channelMessages`, `channelInfo`, `channelReaders` and `ackChannelMessage` resolved the org store from JWT claims but never verified the caller is **subscribed** to the target channel — unlike `sendToChannel` / `uploadToChannel`, which already gate on `s.IsSubscribed`.

Cross-tenant access is already blocked by `db(r)`, but **intra-org** any member could:
- read any channel's full message history, subscriber list and read receipts by iterating channel IDs;
- as a non-subscriber, write ACK / mute / resolved text via `ackChannelMessage` — which can trip an Alertmanager silence.

Closes #152 (API-1).

## Change
- `internal/api/client_channels.go` — gate all four handlers with `s.IsSubscribed(channelID, UserIDFromCtx(r.Context()))` → 403 when not subscribed. `channelInfo` keeps its existence check first, so a missing channel is still `404` (not `403`).

## Tests
- `TestChannelRead_RequiresMembership` — a registered-but-unsubscribed user gets 403 from `/messages`, `/info`, `/readers`, `/ack`. (The user is registered *before* the channel is created, since register auto-subscribes to existing channels.)
- Existing channel tests (subscribed users) still green.
- `go build`, `go vet`, `golangci-lint` (0), `gofmt`, `go test ./... -race -shuffle=on` — clean/green.