### PR TITLE
fix(api,store): clamp the lower bound of ?limit

### DIFF
--- a/internal/api/client_channels.go
+++ b/internal/api/client_channels.go
@@ -206,6 +206,9 @@ func (a *ClientAPI) channelMessages(w http.ResponseWriter, r *http.Request) {
 	if limit > 200 {
 		limit = 200
 	}
+	if limit < 1 {
+		limit = 50 // negative reaches SQLite as LIMIT -1 (unbounded)
+	}
 	msgs, err := s.ChannelMessages(channelID, limit)
 	if err != nil {
 		jsonErr(w, "internal error", 500)

--- a/internal/api/client_chat.go
+++ b/internal/api/client_chat.go
@@ -109,6 +109,9 @@ func (a *ClientAPI) chatMessages(w http.ResponseWriter, r *http.Request) {
 	if limit > 200 {
 		limit = 200
 	}
+	if limit < 1 {
+		limit = 50 // negative reaches SQLite as LIMIT -1 (unbounded)
+	}
 
 	msgs, err := a.db(r).ChatMessages(chatID, limit)
 	if err != nil {

--- a/internal/store/channels.go
+++ b/internal/store/channels.go
@@ -150,6 +150,9 @@ func (s *Store) SaveChannelMessageFrom(channelID int64, sender, senderName, text
 }
 
 func (s *Store) ChannelMessages(channelID int64, limit int) ([]ChannelMessage, error) {
+	if limit < 1 {
+		limit = 50 // guard: a negative LIMIT is "unbounded" in SQLite
+	}
 	rows, err := s.db.Query(
 		"SELECT id, channel_id, COALESCE(sender,'bot'), COALESCE(sender_name,''), COALESCE(text,''), COALESCE(reply_markup,''), COALESCE(reply_to,0), COALESCE(file_id,''), COALESCE(file_type,''), created_at, COALESCE(edited_at,'') FROM channel_messages WHERE channel_id=? ORDER BY id DESC LIMIT ?",
 		channelID, limit,

--- a/internal/store/limit_clamp_test.go
+++ b/internal/store/limit_clamp_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package store
+
+import "testing"
+
+// TestChannelMessagesLimitClamp covers STORE-7/API-2: a negative LIMIT means
+// "unbounded" in SQLite, so a negative/zero limit must be clamped rather than
+// returning the entire channel history.
+func TestChannelMessagesLimitClamp(t *testing.T) {
+	s := newTestStore(t)
+	bot, _ := s.CreateBot("tok-clamp", "B")
+	ch, _ := s.CreateChannel(bot.ID, "clamp", "")
+	for i := 0; i < 60; i++ {
+		if _, err := s.SaveChannelMessage(ch.ID, "m", "", "", ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, lim := range []int{-1, 0, -100} {
+		msgs, err := s.ChannelMessages(ch.ID, lim)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) > 50 {
+			t.Errorf("ChannelMessages(limit=%d) returned %d rows; negative/zero must clamp, not run unbounded", lim, len(msgs))
+		}
+	}
+
+	// A normal limit still works.
+	if msgs, _ := s.ChannelMessages(ch.ID, 10); len(msgs) != 10 {
+		t.Errorf("ChannelMessages(limit=10) = %d rows, want 10", len(msgs))
+	}
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -52,6 +52,9 @@ func (s *Store) DeleteMessage(id int64) error {
 }
 
 func (s *Store) ChatMessages(chatID int64, limit int) ([]Message, error) {
+	if limit < 1 {
+		limit = 50 // guard: a negative LIMIT is "unbounded" in SQLite
+	}
 	rows, err := s.db.Query(
 		"SELECT id, chat_id, sender, COALESCE(text,''), COALESCE(reply_markup,''), COALESCE(file_id,''), COALESCE(file_type,''), created_at FROM messages WHERE chat_id=? ORDER BY created_at DESC LIMIT ?",
 		chatID, limit,


### PR DESCRIPTION
## Summary

`chatMessages` and `channelMessages` clamped only the **upper** bound of `?limit` (`if limit > 200`). A request with `?limit=-1` set `limit=-1`, which is bound into `... LIMIT ?` — and in SQLite a **negative LIMIT means no limit**. An authenticated user could force the entire chat/channel history into a single response: memory/CPU amplification (a cheap DoS) that also defeats pagination.

Closes #151 (STORE-7 / API-2).

## Change
- `internal/api/client_chat.go`, `internal/api/client_channels.go` — clamp `limit < 1` back to the default after parsing.
- `internal/store/messages.go`, `internal/store/channels.go` — defensive guard inside `ChatMessages`/`ChannelMessages`, so a negative LIMIT can never reach SQLite regardless of caller (defense in depth).

## Tests
- `TestChannelMessagesLimitClamp` — inserts 60 messages, asserts `limit=-1/0/-100` return ≤ 50 rows (clamped, not unbounded) and `limit=10` still returns 10.
- `go build`, `go vet`, `golangci-lint` (0), `gofmt`, secret-scan clean, `go test ./... -race -shuffle=on` green (CI/UTC).