### PR TITLE
fix(api): reject tokens whose org no longer resolves

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -831,3 +831,17 @@ func TestChannelRead_RequiresMembership(t *testing.T) {
 		}
 	}
 }
+
+// TestAuthRequired_RejectsDeletedOrg covers API-6: a token whose org no longer
+// resolves must be rejected, not silently served against the default org.
+func TestAuthRequired_RejectsDeletedOrg(t *testing.T) {
+	env := newTestEnv(t)
+	token, err := env.jwt.Generate(1, "ghost-org", "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := env.authedRequest("GET", "/api/chats", nil, token)
+	if rec.Code != 401 {
+		t.Fatalf("token for a non-existent org: got %d, want 401", rec.Code)
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -65,6 +65,16 @@ func (a *ClientAPI) AuthRequired(next http.HandlerFunc) http.HandlerFunc {
 			jsonErr(w, "unauthorized", 401)
 			return
 		}
+		// Reject tokens whose org no longer resolves (e.g. a deleted org).
+		// Without this, db(r) would fall back to the default-org store and the
+		// request would run under the default org's identity — a deleted org's
+		// user_id can collide with the default org's admin (API-6).
+		if a.orgs != nil && claims.OrgID != "" {
+			if _, err := a.orgs.Get(claims.OrgID); err != nil {
+				jsonErr(w, "unauthorized", 401)
+				return
+			}
+		}
 		// Check token revocation
 		rKey := claims.OrgID + ":" + strconv.FormatInt(claims.UserID, 10)
 		if t, ok := revokedUsers.Load(rKey); ok {


### PR DESCRIPTION
## Summary

`AuthRequired` validated the JWT but never checked that the org named in its claims still exists. `db(r)` then falls back to the **default-org** store on a resolution failure, so a token for a **deleted org** ran under the default org's identity — and because each org's `user_id` is a per-database `AUTOINCREMENT`, a deleted org's uid can collide with the default org's admin (`id 1`). With a 7-day JWT TTL and `deleteOrg` not revoking tokens, that window is up to a week.

Resolve the claims org in `AuthRequired` and reject with `401` if it no longer exists.

Closes #153 (API-6).

## Why here, not `db(r)`
The audit suggested changing `db(r)` to return `(store, error)`. That touches ~50 call sites. Doing the check once in the auth middleware closes the fail-open path for every authenticated route at a single chokepoint, with no signature churn. (The `db(r)` fallback now only applies to non-authenticated routes.)

## Cost
`orgs.Get` is an RWMutex-guarded map lookup for an already-open org (cached) — negligible per-request overhead; a non-existent org returns immediately.

## Tests
- `TestAuthRequired_RejectsDeletedOrg` — a JWT for a non-existent org gets 401 on an authed route.
- Existing authed tests (valid-org tokens) unaffected.
- `go build`, `go vet`, `golangci-lint` (0), `gofmt`, `go test ./... -race -shuffle=on` — clean/green.