### PR TITLE
fix(store): check rows.Err() after every list iteration

### DIFF
--- a/internal/store/bots.go
+++ b/internal/store/bots.go
@@ -51,6 +51,9 @@ func (s *Store) ListBots() ([]Bot, error) {
 		}
 		bots = append(bots, b)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return bots, nil
 }
 

--- a/internal/store/channels.go
+++ b/internal/store/channels.go
@@ -70,6 +70,9 @@ func (s *Store) ListChannels() ([]Channel, error) {
 		}
 		chs = append(chs, ch)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return chs, nil
 }
 
@@ -99,6 +102,9 @@ func (s *Store) ChannelSubscribers(channelID int64) ([]int64, error) {
 		}
 		ids = append(ids, id)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return ids, nil
 }
 
@@ -117,6 +123,9 @@ func (s *Store) UserSubscriptions(userID int64) ([]Channel, error) {
 			continue
 		}
 		chs = append(chs, ch)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return chs, nil
 }
@@ -168,6 +177,9 @@ func (s *Store) ChannelMessages(channelID int64, limit int) ([]ChannelMessage, e
 			continue
 		}
 		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return msgs, nil
 }
@@ -299,6 +311,9 @@ func (s *Store) ListChannelsForUser(userID int64) ([]ChannelInfo, error) {
 		ci.Subscribed = sub == 1
 		result = append(result, ci)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -327,6 +342,9 @@ func (s *Store) ChannelSubscribersJoin(channelID int64) ([]ChannelSubscriber, er
 			continue
 		}
 		subs = append(subs, sub)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return subs, nil
 }
@@ -357,6 +375,9 @@ func (s *Store) ChannelReadersJoin(channelID int64) ([]ChannelReader, error) {
 			continue
 		}
 		readers = append(readers, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return readers, nil
 }

--- a/internal/store/chats.go
+++ b/internal/store/chats.go
@@ -38,6 +38,9 @@ func (s *Store) UserChats(userID int64) ([]Chat, error) {
 		}
 		chats = append(chats, c)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return chats, nil
 }
 

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -71,6 +71,9 @@ func (s *Store) ChatMessages(chatID int64, limit int) ([]Message, error) {
 		}
 		msgs = append(msgs, m)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return msgs, nil
 }
 

--- a/internal/store/push.go
+++ b/internal/store/push.go
@@ -40,6 +40,9 @@ func (s *Store) UserPushSubscriptions(userID int64) ([]PushSubscription, error) 
 		}
 		subs = append(subs, sub)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return subs, nil
 }
 

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -58,6 +58,9 @@ func (s *Store) ListUsers() ([]User, error) {
 		}
 		users = append(users, u)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return users, nil
 }
 


### PR DESCRIPTION
## Summary

Every list method looped `for rows.Next()` and returned the slice **without checking `rows.Err()`**. `rows.Next()` returns `false` identically on EOF and on a mid-iteration error, so an iteration error (lock contention, corruption) produced a **silently truncated list with a `nil` error**.

This bites real fan-out paths: `ChannelSubscribers` feeds the WS/push fan-out and `UserPushSubscriptions` feeds Web Push — a short read there silently drops recipients with no log and no error.

Closes #154 (STORE-5).

## Change
Added `if err := rows.Err(); err != nil { return nil, err }` after each `for rows.Next()` loop (12 loops across `channels.go`, `bots.go`, `messages.go`, `chats.go`, `push.go`, `users.go`). Behavior-preserving on the happy path; errors now propagate instead of being swallowed.

## Tests
No new test — forcing `rows.Err()` to return mid-iteration isn't deterministic with the pure-Go SQLite driver. The happy path of every list method is already covered, and `go test ./... -race -shuffle=on` stays green. `go vet`, `golangci-lint` (0), `gofmt` clean.