### PR TITLE
feat(metrics): add delivery-outcome metrics (push, webhook, queue, relay)

### DIFF
--- a/internal/api/client_forward.go
+++ b/internal/api/client_forward.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/pusk-platform/pusk/internal/bot"
+	"github.com/pusk-platform/pusk/internal/metrics"
 	"github.com/pusk-platform/pusk/internal/store"
 )
 
@@ -240,9 +241,11 @@ func sendWebhook(url string, payload interface{}) {
 	//nolint:gosec // G704: admin-configured URL; webhookClient's dialer blocks internal IPs (SSRF)
 	resp, err := webhookClient.Post(url, "application/json", bytes.NewReader(data)) // #nosec G704
 	if err != nil {
+		metrics.WebhookForward.WithLabelValues("failure").Inc()
 		slog.Error("webhook send failed", "url", url, "error", err)
 		return
 	}
 	_ = resp.Body.Close()
+	metrics.WebhookForward.WithLabelValues("success").Inc()
 	slog.Info("webhook sent", "url", url, "status", resp.StatusCode)
 }

--- a/internal/bot/relay.go
+++ b/internal/bot/relay.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/gorilla/websocket"
+	"github.com/pusk-platform/pusk/internal/metrics"
 	"github.com/pusk-platform/pusk/internal/ws"
 )
 
@@ -54,6 +55,7 @@ func (rh *RelayHub) Register(botID int64, c *ws.Conn) {
 		old.Send([]byte(`{"type":"replaced"}`))
 	}
 	rh.conns[botID] = c
+	metrics.RelayBotsConnected.Set(float64(len(rh.conns)))
 	slog.Info("relay bot connected", "bot_id", botID)
 }
 
@@ -62,6 +64,7 @@ func (rh *RelayHub) Unregister(botID int64, c *ws.Conn) {
 	defer rh.mu.Unlock()
 	if cur, ok := rh.conns[botID]; ok && cur == c {
 		delete(rh.conns, botID)
+		metrics.RelayBotsConnected.Set(float64(len(rh.conns)))
 		slog.Info("relay bot disconnected", "bot_id", botID)
 	}
 }

--- a/internal/bot/updates.go
+++ b/internal/bot/updates.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/pusk-platform/pusk/internal/metrics"
 )
 
 // Update represents a Telegram-compatible update object for long polling.
@@ -60,6 +62,7 @@ func (q *UpdateQueue) Push(botID int64, u Update) {
 	case ch <- u:
 		slog.Debug("update queued", "bot_id", botID, "update_id", u.UpdateID)
 	default:
+		metrics.UpdateQueueDropped.Inc()
 		slog.Warn("update queue full, dropping", "bot_id", botID, "update_id", u.UpdateID)
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -58,6 +58,34 @@ var (
 			Help: "Total registered users across all orgs",
 		},
 	)
+	// Delivery-outcome metrics: without these the platform's primary function
+	// (did the alert actually reach a recipient?) is unobservable.
+	PushTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusk_push_total",
+			Help: "Web Push notifications by result",
+		},
+		[]string{"result"}, // sent | failed | stale
+	)
+	WebhookForward = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusk_webhook_forward_total",
+			Help: "Outbound webhook deliveries by result",
+		},
+		[]string{"result"}, // success | failure
+	)
+	UpdateQueueDropped = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pusk_update_queue_dropped_total",
+			Help: "Bot update-queue messages dropped because the queue was full",
+		},
+	)
+	RelayBotsConnected = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "pusk_relay_bots_connected",
+			Help: "Bots currently connected via WebSocket relay",
+		},
+	)
 )
 
 func init() {
@@ -70,5 +98,9 @@ func init() {
 		WebhooksDedupedTotal,
 		OrgsTotal,
 		UsersTotal,
+		PushTotal,
+		WebhookForward,
+		UpdateQueueDropped,
+		RelayBotsConnected,
 	)
 }

--- a/internal/notify/push.go
+++ b/internal/notify/push.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	webpush "github.com/SherClockHolmes/webpush-go"
+	"github.com/pusk-platform/pusk/internal/metrics"
 	"github.com/pusk-platform/pusk/internal/store"
 )
 
@@ -133,6 +134,10 @@ func (p *PushService) SendToUser(s *store.Store, userID int64, payload PushPaylo
 			sent++
 		}
 	}
+
+	metrics.PushTotal.WithLabelValues("sent").Add(float64(sent))
+	metrics.PushTotal.WithLabelValues("failed").Add(float64(failed))
+	metrics.PushTotal.WithLabelValues("stale").Add(float64(stale))
 
 	slog.Info(
 		"push delivered",


### PR DESCRIPTION
## Summary

Operators could see webhooks **received** (`pusk_webhooks_total`) but not whether the resulting alert was **delivered**, and the bot update queue dropped messages silently (`slog.Warn` only). The platform's primary SLO was unobservable.

Adds four delivery-outcome metrics:
- `pusk_push_total{result}` — `sent` / `failed` / `stale` (push fan-out)
- `pusk_webhook_forward_total{result}` — `success` / `failure` (outbound `sendWebhook`)
- `pusk_update_queue_dropped_total` — the previously-silent full-queue drop
- `pusk_relay_bots_connected` — gauge of bots connected via WS relay

Closes #155 (REL-6).

## Notes
- **Additive only** — no existing metric names change, so current Grafana dashboards are unaffected.
- Low cardinality: results are fixed enums; no per-bot/per-org labels.
- `pusk_alert_delivery_total{transport}` and a queue-depth gauge would be a natural follow-up but need wiring at every delivery path / per-channel tracking; deferred.

## Testing
Metrics are additive plumbing; `init()` registration is exercised by every test that imports the packages (a duplicate/typo would panic on init). `go build`, `go vet`, `golangci-lint` (0), `gofmt` clean; `go test ./... -race` green.