### PR TITLE
fix: recover from panics in the request chain and forward goroutines

### DIFF
--- a/cmd/pusk/main.go
+++ b/cmd/pusk/main.go
@@ -237,7 +237,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:              *addr,
-		Handler:           securityHeaders(api.RequestLogger(bot.TelegramCompat(mux))),
+		Handler:           api.Recover(securityHeaders(api.RequestLogger(bot.TelegramCompat(mux)))),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 

--- a/internal/api/client_forward.go
+++ b/internal/api/client_forward.go
@@ -94,6 +94,7 @@ func (a *ClientAPI) pushCallbackToQueue(s *store.Store, chatID, userID int64, da
 }
 
 func (a *ClientAPI) forwardToBot(s *store.Store, chatID, userID int64, msg *store.Message) {
+	defer recoverLog("forwardToBot")
 	botID, err := s.ChatBotID(chatID)
 	if err != nil || botID == 0 {
 		slog.Warn("no bot for chat", "chat_id", chatID)
@@ -142,6 +143,7 @@ func (a *ClientAPI) forwardToBot(s *store.Store, chatID, userID int64, msg *stor
 }
 
 func (a *ClientAPI) forwardCallback(s *store.Store, chatID, userID int64, data string, messageID int64) {
+	defer recoverLog("forwardCallback")
 	slog.Info("forwardCallback called", "chat_id", chatID, "user_id", userID, "data", data, "msg_id", messageID)
 	botID, err := s.ChatBotID(chatID)
 	if err != nil || botID == 0 {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -4,13 +4,38 @@ package api
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/pusk-platform/pusk/internal/auth"
 )
+
+// Recover wraps a handler so a panic anywhere downstream is logged with a stack
+// trace and turned into a 500, instead of an abrupt connection drop with no log.
+func Recover(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				slog.Error("panic in handler", "panic", rec, "path", r.URL.Path, "stack", string(debug.Stack()))
+				jsonErr(w, "internal error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// recoverLog recovers a panic in a spawned goroutine and logs it. net/http only
+// recovers panics on the request goroutine, so any `go func()` must guard itself
+// or a single panic takes down the whole process.
+func recoverLog(where string) {
+	if rec := recover(); rec != nil {
+		slog.Error("recovered panic in goroutine", "where", where, "panic", rec, "stack", string(debug.Stack()))
+	}
+}
 
 type ctxKey int
 

--- a/internal/api/recover_test.go
+++ b/internal/api/recover_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Licensed under the Business Source License 1.1. See LICENSE file for details.
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRecover_PanicReturns500 covers REL-1: a panicking handler is caught,
+// logged, and turned into a 500 rather than propagating.
+func TestRecover_PanicReturns500(t *testing.T) {
+	h := Recover(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	}))
+	rec := httptest.NewRecorder()
+	// ServeHTTP must not re-panic.
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/x", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("got %d, want 500", rec.Code)
+	}
+}
+
+// TestRecover_PassesThrough confirms a normal handler is unaffected.
+func TestRecover_PassesThrough(t *testing.T) {
+	h := Recover(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/x", nil))
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("got %d, want 418", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

`net/http` recovers a panic on the request goroutine (it closes that one connection), but a panic inside a **manually-spawned goroutine** — `go a.forwardToBot(...)`, `go a.forwardCallback(...)` — is **not** recovered and crashes the whole process, taking down alerting for every tenant. No reachable panic exists today, but this is the defense-in-depth net the audit flagged as missing.

Adds:
- **`Recover`** HTTP middleware — logs the panic + stack and returns `500` instead of an abrupt connection drop; wraps the whole handler chain in `main.go`.
- **`recoverLog()`** guard `defer`'d on the `forwardToBot` / `forwardCallback` goroutines.

The channel push fan-out goroutine already recovers (added in #147 / the async fan-out PR).

Closes #156 (REL-1).

## Notes
- `WritePump` (ws) and the retention/cleanup tickers are further `go`-spawn candidates; left for a focused follow-up to keep this change small. None process attacker-influenced data the way the forward goroutines do.

## Tests
- `TestRecover_PanicReturns500` / `TestRecover_PassesThrough`.
- `go build`, `go vet`, `golangci-lint` (0), `gofmt`, `go test ./... -race -shuffle=on` — clean/green.