### PR TITLE
chore: low-severity cleanup — tests, CI pin, store/org correctness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: gosec — static security analysis
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
           gosec -severity medium -quiet -exclude=G104 ./...
 
       - name: govulncheck — Go vulnerability database

--- a/internal/api/client_auth.go
+++ b/internal/api/client_auth.go
@@ -343,7 +343,7 @@ func (a *ClientAPI) orgStats(w http.ResponseWriter, r *http.Request) {
 	}
 	users, _ := s.ListUsers()
 	channels, _ := s.ListChannels()
-	msgCount := s.MessageCount()
+	msgCount := s.ChannelMessageCount()
 	fileSize := s.TotalFileSize()
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"users":     len(users),

--- a/internal/org/manager.go
+++ b/internal/org/manager.go
@@ -215,7 +215,9 @@ func (m *Manager) Register(slug, name, adminUser, adminPin string, bypassLimit b
 
 	// Create default system bot (needed for channels)
 	tokenBytes := make([]byte, 16)
-	crand.Read(tokenBytes)
+	if _, err := crand.Read(tokenBytes); err != nil {
+		return fmt.Errorf("generate system bot token: %w", err)
+	}
 	botToken := hex.EncodeToString(tokenBytes)
 	sysBot, _ := s.CreateBot(botToken, name+" Bot")
 	if sysBot != nil {
@@ -224,7 +226,7 @@ func (m *Manager) Register(slug, name, adminUser, adminPin string, bypassLimit b
 		// Create #general channel with welcome message
 		ch, _ := s.CreateChannel(sysBot.ID, "general", "General channel")
 		if ch != nil {
-			_ = s.Subscribe(ch.ID, 1) // admin user_id = 1
+			_ = s.Subscribe(ch.ID, admin.ID) // subscribe the org admin to #general
 			welcome := fmt.Sprintf("Welcome to **%s**! / Добро пожаловать в **%s**!\n\n"+
 				"This is #general — your team's chat channel.\n"+
 				"Это #general — канал для общения команды.\n\n"+

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -77,7 +77,8 @@ func (s *Store) ChatMessages(chatID int64, limit int) ([]Message, error) {
 	return msgs, nil
 }
 
-func (s *Store) MessageCount() int64 {
+// ChannelMessageCount returns the number of channel messages (not DMs).
+func (s *Store) ChannelMessageCount() int64 {
 	var count int64
 	//nolint:errcheck // returns 0 on error
 	s.db.QueryRow("SELECT COUNT(*) FROM channel_messages").Scan(&count)

--- a/internal/store/store_extra_test.go
+++ b/internal/store/store_extra_test.go
@@ -188,7 +188,7 @@ func TestCleanOldChannelMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	future := time.Now().Add(time.Hour).Format(time.RFC3339)
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
 	s.CleanOldChannelMessages(future)
 
 	msgs, err := s.ChannelMessages(ch.ID, 100)
@@ -367,7 +367,7 @@ func TestMessageCount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	count := s.MessageCount()
+	count := s.ChannelMessageCount()
 	if count != 3 {
 		t.Errorf("message count = %d, want 3", count)
 	}
@@ -376,7 +376,7 @@ func TestMessageCount(t *testing.T) {
 func TestMessageCount_Empty(t *testing.T) {
 	s := newTestStore(t)
 
-	count := s.MessageCount()
+	count := s.ChannelMessageCount()
 	if count != 0 {
 		t.Errorf("message count = %d, want 0", count)
 	}


### PR DESCRIPTION
First batch of low-severity findings from the audit tracking issue #159.

| ID | Fix |
|----|-----|
| **TEST-1** | `TestCleanOldChannelMessages` builds its cutoff with `.UTC()` to match stored timestamps — no longer fails outside UTC (the runner happened to be UTC, masking it). |
| **CI-1** | Pin `gosec@latest` → `gosec@v2.27.1` for a reproducible security gate. |
| **STORE-8** | Rename `MessageCount` → `ChannelMessageCount` (it counts `channel_messages`, not DMs) + the two test callers and the admin-stats caller. |
| **STORE-9** | Subscribe the captured `admin.ID` to `#general` instead of the hardcoded `user_id=1`. |
| **ARCH-6** | Check `crypto/rand.Read` and fail org creation on an entropy error. |

Also reconciled as **already fixed** by earlier merged PRs / current main (no change needed):
- **STORE-2** (per-connection PRAGMAs) and **STORE-3** (foreign keys) — both applied via the DSN `_pragma=...` in #160.
- **PROC-2** — `SECURITY.md` already lists `0.7.x` as supported.

Left out of this batch: **TEST-3** — a meaningful `Version != "dev"` assertion needs a release build tag (the default is `"dev"` and `go test` doesn't apply ldflags), so a naive change would fail plain `go test`; deferred.

Refs #159. `go test ./... -race -shuffle=on`, golangci-lint (0), gofumpt, valid YAML — all green.