### PR TITLE
fix(api): recover from panics in the /start forward goroutine

### DIFF
--- a/internal/api/client_chat.go
+++ b/internal/api/client_chat.go
@@ -79,6 +79,7 @@ func (a *ClientAPI) startChat(w http.ResponseWriter, r *http.Request) {
 			"message":   startMsg,
 		}
 		go func() {
+			defer recoverLog("startChat")
 			// Push to update queue for getUpdates long polling
 			if a.updates != nil {
 				a.updates.Push(b.ID, bot.Update{

--- a/internal/api/recover_test.go
+++ b/internal/api/recover_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // TestRecover_PanicReturns500 covers REL-1: a panicking handler is caught,
@@ -31,5 +32,31 @@ func TestRecover_PassesThrough(t *testing.T) {
 	h.ServeHTTP(rec, httptest.NewRequest("GET", "/x", nil))
 	if rec.Code != http.StatusTeapot {
 		t.Fatalf("got %d, want 418", rec.Code)
+	}
+}
+
+// TestRecoverLog_RecoversGoroutinePanic locks the primitive that startChat's
+// inline /start forward goroutine relies on: `defer recoverLog(...)` must swallow
+// a panic so a panicking spawned goroutine cannot crash the whole process (a
+// spawned goroutine's panic is not covered by the request-chain Recover
+// middleware). The contract gate enforces that startChat actually defers
+// recoverLog; this proves recoverLog does recover. The outer deferred recover()
+// runs after recoverLog (LIFO): it observes nil iff recoverLog already consumed
+// the panic, and otherwise catches it itself so a regression fails cleanly here
+// instead of taking down the test binary.
+func TestRecoverLog_RecoversGoroutinePanic(t *testing.T) {
+	recovered := make(chan bool, 1)
+	go func() {
+		defer func() { recovered <- (recover() == nil) }()
+		defer recoverLog("startChat")
+		panic("boom in forward goroutine")
+	}()
+	select {
+	case ok := <-recovered:
+		if !ok {
+			t.Fatal("recoverLog did not recover the panic — a spawned goroutine panic would crash the process")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not complete")
 	}
 }


### PR DESCRIPTION
The inline goroutine in `startChat` that forwards the synthetic `/start` update (via `updates.Push` / `relay.Send` / `sendWebhook`) had no panic recovery, unlike its siblings `forwardToBot` and `forwardCallback` which both `defer recoverLog`. An unrecovered panic in a spawned goroutine crashes the whole process — the request-chain `Recover` middleware only covers the request goroutine, not ones it spawns.

Guard it the same way, and add `TestRecoverLog_RecoversGoroutinePanic` locking the recovery primitive (a deferred `recoverLog` must swallow a goroutine panic).