### PR TITLE
fix(api): require channel membership to mark a channel read

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -823,6 +823,7 @@ func TestChannelRead_RequiresMembership(t *testing.T) {
 		{"GET", base + "/info", nil},
 		{"GET", base + "/readers", nil},
 		{"POST", base + "/ack", map[string]interface{}{"message_id": 1, "action": "ack"}},
+		{"POST", base + "/mark-read", nil},
 	}
 	for _, c := range cases {
 		rec := env.authedRequest(c.method, c.path, c.body, token)

--- a/internal/api/client_channels.go
+++ b/internal/api/client_channels.go
@@ -225,6 +225,11 @@ func (a *ClientAPI) markChannelRead(w http.ResponseWriter, r *http.Request) {
 	channelID, _ := strconv.ParseInt(r.PathValue("channelID"), 10, 64)
 	s := a.db(r)
 
+	if !s.IsSubscribed(channelID, userID) {
+		jsonErr(w, "not subscribed", 403)
+		return
+	}
+
 	var req struct {
 		LastReadID int64 `json:"last_read_id"`
 	}


### PR DESCRIPTION
`markChannelRead` wrote a per-user read cursor for an arbitrary `channelID` (and probed the latest message id via `ChannelMessages`) without checking that the caller is subscribed — unlike every sibling channel handler (messages, info, readers, ack, send), which gate on `IsSubscribed`.

Add the same 403 guard so a non-member cannot write read-state for, or probe the latest message id of, a channel they are not in. Extends `TestChannelRead_RequiresMembership` with the mark-read endpoint.