### PR TITLE
ci: auto-merge Dependabot patch/minor + group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,15 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "deps"
+    # Bundle minor/patch into one PR (avoids go.mod conflicts across PRs);
+    # majors stay separate for manual review.
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -13,6 +22,13 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci"
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/tests/e2e"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,36 @@
+name: Dependabot auto-merge
+
+# Enables auto-merge for Dependabot patch & minor updates once all required
+# checks pass. Major bumps are deliberately left for manual review.
+#
+# Uses `on: pull_request` (not pull_request_target): Dependabot PRs honour the
+# `permissions:` block below and expose secrets.GITHUB_TOKEN, so no elevated
+# trigger is needed. Requires repo setting "Allow auto-merge" to be enabled.
+
+on: pull_request
+
+permissions: read-all
+
+jobs:
+  automerge:
+    name: Auto-merge patch & minor
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch & minor
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

- **New** `.github/workflows/dependabot-automerge.yml` — enables auto-merge (squash, delete branch) on Dependabot PRs once all required checks pass, restricted to **patch & minor** via `dependabot/fetch-metadata`. Major bumps stay manual.
- **Update** `.github/dependabot.yml` — group `gomod` and `github-actions` minor/patch into single PRs; majors remain individual.

## Why

This week produced 7 separate Dependabot PRs; strict branch protection (`require up-to-date`) plus two bumps touching `go.mod` forced serial rebasing and a manual conflict `recreate`. Grouping collapses the weekly minor/patch churn into one PR per ecosystem and removes cross-PR `go.mod` conflicts; auto-merge drains the safe ones hands-free.

## Safety notes

- Trigger is `on: pull_request` (not `pull_request_target`): Dependabot PRs honour the declared `permissions:` and expose `secrets.GITHUB_TOKEN`, so no elevated trigger is needed.
- Least privilege: workflow `read-all`, job `contents: write` + `pull-requests: write` only.
- `dependabot/fetch-metadata` pinned to full SHA (`25dd0e3`, v3.1.0), matching the repo's Scorecard-pinned convention.
- Requires the repo **"Allow auto-merge"** setting (enabled).
- No auto-approve step: `main` has no required reviews, so it would only add failure surface.

## Not addressed here

Strict branch protection still means two *major* bumps in the same week can require serial manual rebasing (majors are excluded from groups by design).